### PR TITLE
Fix proto_rpc streaming alias and clean method parsing

### DIFF
--- a/crates/prosto_derive/src/proto_rpc/server.rs
+++ b/crates/prosto_derive/src/proto_rpc/server.rs
@@ -212,7 +212,7 @@ fn generate_blanket_impl_components(methods: &[MethodInfo], trait_name: &syn::Id
 
     for method in methods {
         if is_streaming_method(method) {
-            blanket_types.push(generate_blanket_stream_type(method));
+            blanket_types.push(generate_blanket_stream_type(method, trait_name));
         }
         blanket_methods.push(generate_blanket_method(method, trait_name));
     }
@@ -220,14 +220,9 @@ fn generate_blanket_impl_components(methods: &[MethodInfo], trait_name: &syn::Id
     (blanket_types, blanket_methods)
 }
 
-fn generate_blanket_stream_type(method: &MethodInfo) -> TokenStream {
+fn generate_blanket_stream_type(method: &MethodInfo, trait_name: &syn::Ident) -> TokenStream {
     let stream_name = method.stream_type_name.as_ref().unwrap();
-    let inner_type = method.inner_response_type.as_ref().unwrap();
-    let response_proto = generate_response_proto_type(inner_type);
-
-    quote! {
-        type #stream_name = std::pin::Pin<Box<dyn tonic::codegen::tokio_stream::Stream<Item = std::result::Result<#response_proto, tonic::Status>> + std::marker::Send>>;
-    }
+    quote! { type #stream_name = <Self as super::#trait_name>::#stream_name; }
 }
 
 fn generate_blanket_method(method: &MethodInfo, trait_name: &syn::Ident) -> TokenStream {

--- a/crates/prosto_derive/src/proto_rpc/utils.rs
+++ b/crates/prosto_derive/src/proto_rpc/utils.rs
@@ -21,7 +21,6 @@ pub fn extract_methods_and_types(input: &ItemTrait) -> (Vec<MethodInfo>, Vec<Tok
         match item {
             TraitItem::Fn(method) => {
                 let method_name = method.sig.ident.clone();
-                let method_attrs = method.attrs.clone();
                 let (request_type, response_type) = extract_types(&method.sig);
                 let is_streaming = is_stream_response(&method.sig);
 
@@ -44,11 +43,10 @@ pub fn extract_methods_and_types(input: &ItemTrait) -> (Vec<MethodInfo>, Vec<Tok
                     (None, None)
                 };
 
-                let user_method_signature = generate_user_method_signature(&method_attrs, &method_name, &request_type, &response_type, is_streaming, stream_type_name.as_ref());
+                let user_method_signature = generate_user_method_signature(&method.attrs, &method_name, &request_type, &response_type, is_streaming, stream_type_name.as_ref());
 
                 methods.push(MethodInfo {
                     name: method_name,
-                    _attrs: method_attrs,
                     request_type,
                     response_type,
                     is_streaming,

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -132,7 +132,6 @@ pub fn is_complex_type(ty: &Type) -> bool {
 
 pub struct MethodInfo {
     pub name: syn::Ident,
-    pub _attrs: Vec<syn::Attribute>,
     pub request_type: Box<Type>,
     pub response_type: Box<Type>,
     pub is_streaming: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,7 @@ pub use prosto_derive::proto_rpc;
 const RECURSION_LIMIT: u32 = 100;
 
 mod arrays;
-mod custom_types;
-
-pub use custom_types::*;
+pub mod custom_types;
 
 #[doc(hidden)]
 pub extern crate alloc;


### PR DESCRIPTION
## Summary
- align generated server blanket impls with user-defined streaming associated types
- simplify proto_rpc method extraction and drop unused metadata to avoid duplication
- expose the custom_types module directly to remove an unused re-export warning

## Testing
- cargo check
- cargo run --example complex

------
https://chatgpt.com/codex/tasks/task_e_68eb5a5e07a083218e7ec0b0c6db924f