### PR TITLE
Add skip post-processing and conversion hooks for proto macro

### DIFF
--- a/examples/prosto_proto.rs
+++ b/examples/prosto_proto.rs
@@ -322,6 +322,26 @@ pub struct Attr {
     pub updated_at: DateTime<Utc>,
 }
 
+fn compute_hash(user: &User) -> String {
+    format!("{}:{}", user.id, user.name)
+}
+
+fn get_current_timestamp(_user: &User) -> DateTime<Utc> {
+    Utc::now()
+}
+
+fn compute_hash_for_struct(attr: &Attr) -> String {
+    let mut parts = attr.id_vec.join("|");
+    if let Some(opt) = &attr.id_opt {
+        if !parts.is_empty() {
+            parts.push('|');
+        }
+        parts.push_str(opt);
+    }
+
+    format!("{}|{:?}|{:?}", parts, attr.status, attr.status_opt)
+}
+
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SimpleMessage {


### PR DESCRIPTION
## Summary
- allow #[proto(skip = "fn")] fields to recompute values after decode while keeping safe defaults
- reuse into/from conversion metadata for decode paths and default/clear logic so non-ProtoExt types work
- demonstrate the feature in examples with helper functions for computing hashes and timestamps

## Testing
- cargo check --examples

------
https://chatgpt.com/codex/tasks/task_e_68eb81acc09c8321b71aebfd7ac3d447