### PR TITLE
Introduce ProtoEnum marker trait for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,8 @@ pub struct Attr {
     id_skip: Vec<i64>,
     id_vec: Vec<String>,
     id_opt: Option<String>,
-    #[proto(rust_enum)]
     status: Status,
-    #[proto(rust_enum)]
     status_opt: Option<Status>,
-    #[proto(rust_enum)]
     status_vec: Vec<Status>,
     #[proto(skip = "compute_hash_for_struct")]
     hash: String,
@@ -250,11 +247,8 @@ pub enum VeryComplex {
         id_skip: Vec<i64>,
         id_vec: Vec<String>,
         id_opt: Option<String>,
-        #[proto(rust_enum)]
         status: Status,
-        #[proto(rust_enum)]
         status_opt: Option<Status>,
-        #[proto(rust_enum)]
         status_vec: Vec<Status>,
         #[proto(skip = "compute_hash_for_enum")]
         hash: String,

--- a/crates/prosto_derive/src/proto_rpc/client.rs
+++ b/crates/prosto_derive/src/proto_rpc/client.rs
@@ -61,7 +61,7 @@ pub fn generate_client_module(trait_name: &syn::Ident, vis: &syn::Visibility, pa
             where
                 T: tonic::client::GrpcService<tonic::body::Body>,
                 T::Error: Into<StdError>,
-                T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+                T::ResponseBody: Body<Data = ::proto_rs::bytes::Bytes> + std::marker::Send + 'static,
                 <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
             {
                 pub fn new(inner: T) -> Self {

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -14,8 +14,6 @@ pub mod type_conversion;
 pub mod type_info;
 
 pub use string_helpers::*;
-pub use type_conversion::get_proto_rust_type;
-pub use type_conversion::needs_into_conversion;
 pub use type_info::ParsedFieldType;
 pub use type_info::is_bytes_array;
 pub use type_info::is_bytes_vec;

--- a/crates/prosto_derive/src/utils/type_conversion.rs
+++ b/crates/prosto_derive/src/utils/type_conversion.rs
@@ -7,6 +7,7 @@ use super::type_info::is_bytes_array;
 
 /// Get the proto-equivalent Rust type (handles size conversions)
 /// Maps Rust types to their protobuf-compatible equivalents
+#[allow(dead_code)]
 pub fn get_proto_rust_type(ty: &Type) -> Type {
     // Handle arrays
     if let Type::Array(type_array) = ty {
@@ -46,6 +47,7 @@ pub fn get_proto_rust_type(ty: &Type) -> Type {
 
 /// Check if type needs .into() conversion for to_proto
 /// Returns true for types that are smaller than their proto representation
+#[allow(dead_code)]
 pub fn needs_into_conversion(ty: &Type) -> bool {
     if let Type::Path(type_path) = ty {
         return type_path

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -28,7 +28,6 @@ pub struct Id {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RizzPing {
     id: Id,
-    #[proto(rust_enum)]
     status: ServiceStatus,
 }
 
@@ -36,7 +35,6 @@ pub struct RizzPing {
 #[derive(Clone, Debug, PartialEq)]
 pub struct GoonPong {
     id: Id,
-    #[proto(rust_enum)]
     status: ServiceStatus,
 }
 

--- a/examples/prosto_proto.rs
+++ b/examples/prosto_proto.rs
@@ -131,15 +131,12 @@ pub enum Status {
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
 pub enum EnumArrayRustEnumAttributeFailTest {
-    Fail {
-        #[proto(rust_enum)]
-        timestamp_array: [Status; 8],
-    },
+    Fail { timestamp_array: [Status; 8] },
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
 pub enum EnumArrayRustEnumAttributeFailTest2 {
-    Fail(#[proto(rust_enum)] [Status; 8]),
+    Fail([Status; 8]),
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
@@ -175,55 +172,30 @@ pub enum VecTestEnumProst {
 #[derive(Clone)]
 pub enum VecTestEnumCustom {
     Test,
-    Test0(#[proto(rust_enum)] Status),
-    Test1(#[proto(rust_enum)] Vec<Status>),
-    Test2 {
-        #[proto(rust_enum)]
-        test1: Vec<Status>,
-        #[proto(rust_enum)]
-        test2: Option<Status>,
-        #[proto(rust_enum)]
-        test3: Status,
-    },
-    Test3(#[proto(rust_enum)] Option<Status>),
+    Test0(Status),
+    Test1(Vec<Status>),
+    Test2 { test1: Vec<Status>, test2: Option<Status>, test3: Status },
+    Test3(Option<Status>),
 
     Test7(User),
     Test8(Option<User>),
     Test9(Vec<User>),
-    Test10 {
-        test: Vec<User>,
-        test1: Option<User>,
-        test3: User,
-    },
+    Test10 { test: Vec<User>, test1: Option<User>, test3: User },
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
 #[derive(Clone)]
 pub enum VecTestEnumCustom2 {
-    Test0(#[proto(rust_enum)] Status),
-    Test1(#[proto(rust_enum)] Vec<Status>),
-    Test2 {
-        #[proto(rust_enum)]
-        test1: Vec<Status>,
-        #[proto(rust_enum)]
-        test2: Option<Status>,
-        #[proto(rust_enum)]
-        test3: Status,
-    },
-    Test3(#[proto(rust_enum)] Option<Status>),
+    Test0(Status),
+    Test1(Vec<Status>),
+    Test2 { test1: Vec<Status>, test2: Option<Status>, test3: Status },
+    Test3(Option<Status>),
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
 #[derive(Clone)]
 pub enum VecFailingTestEnum {
-    Test2 {
-        #[proto(rust_enum)]
-        test1: Vec<Status>,
-        #[proto(rust_enum)]
-        test2: Option<Status>,
-        #[proto(rust_enum)]
-        test3: Status,
-    },
+    Test2 { test1: Vec<Status>, test2: Option<Status>, test3: Status },
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
@@ -292,11 +264,8 @@ pub enum VeryComplex {
         id_skip: Vec<i64>,
         id_vec: Vec<String>,
         id_opt: Option<String>,
-        #[proto(rust_enum)]
         status: Status,
-        #[proto(rust_enum)]
         status_opt: Option<Status>,
-        #[proto(rust_enum)]
         status_vec: Vec<Status>,
         #[proto(skip = "compute_hash_for_enum")]
         hash: String,
@@ -309,11 +278,8 @@ pub struct Attr {
     id_skip: Vec<i64>,
     id_vec: Vec<String>,
     id_opt: Option<String>,
-    #[proto(rust_enum)]
     status: Status,
-    #[proto(rust_enum)]
     status_opt: Option<Status>,
-    #[proto(rust_enum)]
     status_vec: Vec<Status>,
     #[proto(skip = "compute_hash_for_struct")]
     hash: String,
@@ -340,6 +306,39 @@ fn compute_hash_for_struct(attr: &Attr) -> String {
     }
 
     format!("{}|{:?}|{:?}", parts, attr.status, attr.status_opt)
+}
+
+fn compute_hash_for_enum_test(value: &VeryComplexTestSkip) -> String {
+    match value {
+        VeryComplexTestSkip::Attr { hash_2, .. } => format!("enum-attr:{hash_2}"),
+        VeryComplexTestSkip::Tuple(inner) => format!("enum-tuple:{inner}"),
+        VeryComplexTestSkip::Tuple2(inner) => format!("enum-tuple2:{inner}"),
+    }
+}
+
+fn compute_hash_for_enum_test_2(value: &VeryComplexTestSkip) -> String {
+    match value {
+        VeryComplexTestSkip::Tuple(inner) => format!("tuple-only:{inner}"),
+        _ => compute_hash_for_enum_test(value),
+    }
+}
+
+fn compute_hash_for_enum(value: &VeryComplex) -> String {
+    match value {
+        VeryComplex::Attr {
+            id_vec, id_opt, status, status_opt, ..
+        } => {
+            let mut parts = id_vec.join("|");
+            if let Some(opt) = id_opt {
+                if !parts.is_empty() {
+                    parts.push('|');
+                }
+                parts.push_str(opt);
+            }
+            format!("{}|{:?}|{:?}", parts, status, status_opt)
+        }
+        _ => String::new(),
+    }
 }
 
 #[proto_message(proto_path = "protos/showcase_proto/show.proto")]
@@ -459,7 +458,6 @@ pub struct Invoice {
     pub id: u64,
     pub customer: Person,
     pub payments: Vec<Payment>,
-    #[proto(rust_enum)]
     pub status: Status,
     #[proto(skip)]
     pub internal_notes: String,
@@ -555,7 +553,6 @@ pub struct ComplexConversions {
     pub internal_state: String,
 
     // Simple enum
-    #[proto(rust_enum)]
     pub status: Status,
 
     // Regular field

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::encoding::length_delimiter::length_delimiter_len;
 pub use crate::error::DecodeError;
 pub use crate::error::EncodeError;
 pub use crate::error::UnknownEnumValue;
-pub use crate::message::{MessageField, ProtoExt, RepeatedField, SingularField};
+pub use crate::message::{MessageField, ProtoEnum, ProtoExt, RepeatedField, SingularField};
 pub use crate::name::Name;
 pub use crate::tonic::ProtoCodec;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -169,6 +169,25 @@ pub trait ProtoExt {
 /// implementations for collections of nested messages.
 pub trait MessageField: ProtoExt {}
 
+/// Marker trait for enums encoded as plain `int32` values on the wire.
+///
+/// Derive macros mark unit enums with this trait so other generated code can
+/// reliably treat them as scalar fields. Manual implementations can opt in to
+/// the same behaviour by providing the conversions required here alongside the
+/// appropriate [`ProtoExt`], [`SingularField`], and [`RepeatedField`]
+/// implementations.
+pub trait ProtoEnum: Copy + Sized {
+    /// Default value used when decoding absent fields.
+    const DEFAULT_VALUE: Self;
+
+    /// Convert a raw `i32` value into the enum, returning a [`DecodeError`]
+    /// when the value is not recognised.
+    fn from_i32(value: i32) -> Result<Self, DecodeError>;
+
+    /// Convert the enum into its raw `i32` representation.
+    fn to_i32(self) -> i32;
+}
+
 /// Trait describing how to encode, decode, and size a single field value.
 ///
 /// Implementations exist for all scalar protobuf types, as well as the message

--- a/tests/proto_build_test/src/main.rs
+++ b/tests/proto_build_test/src/main.rs
@@ -23,7 +23,6 @@ pub struct Id {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RizzPing {
     id: Id,
-    #[proto(rust_enum)]
     status: ServiceStatus,
 }
 
@@ -31,7 +30,6 @@ pub struct RizzPing {
 #[derive(Clone, Debug, PartialEq)]
 pub struct GoonPong {
     id: Id,
-    #[proto(rust_enum)]
     status: ServiceStatus,
 }
 


### PR DESCRIPTION
## Summary
- add a public `ProtoEnum` marker trait and re-export it so enums can opt into rust-enum scalar behaviour
- make `proto_message` unit enums implement the marker trait directly instead of populating a shared registry
- drop the derive-time registry plumbing and simplify type analysis now that enum detection no longer depends on macro order

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68eb899fdc4083219f0a03e73ff2a3bd