### PR TITLE
Stop appending Proto suffix in generated proto messages

### DIFF
--- a/crates/prosto_derive/src/emit_proto.rs
+++ b/crates/prosto_derive/src/emit_proto.rs
@@ -38,7 +38,7 @@ pub fn generate_simple_enum_proto(name: &str, data: &DataEnum) -> String {
 }
 
 pub fn generate_complex_enum_proto(name: &str, data: &DataEnum) -> String {
-    let proto_name = format!("{}Proto", name);
+    let proto_name = name.to_string();
 
     let mut nested_messages = Vec::new();
     let mut oneof_fields = Vec::new();


### PR DESCRIPTION
## Summary
- stop appending the `Proto` suffix when generating proto messages for complex enums so that the emitted `.proto` definitions keep their original names

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68eb97f0cfdc832187dcadd7293b8541