### PR TITLE
Add map and set support to proto derive

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -202,6 +202,25 @@ fn extract_field_type_name(ty: &syn::Type) -> String {
             return rust_type_path_ident(inner_ty).to_string();
         }
 
+        if matches!(ident.to_string().as_str(), "HashMap" | "BTreeMap")
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        {
+            let mut generics = args.args.iter().filter_map(|arg| match arg {
+                syn::GenericArgument::Type(inner_ty) => Some(inner_ty.clone()),
+                _ => None,
+            });
+
+            let value_ty = generics.nth(1).unwrap_or_else(|| ty.clone());
+            return rust_type_path_ident(&value_ty).to_string();
+        }
+
+        if matches!(ident.to_string().as_str(), "HashSet" | "BTreeSet")
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+            && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
+        {
+            return rust_type_path_ident(inner_ty).to_string();
+        }
+
         return ident.to_string();
     }
 

--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -179,7 +179,8 @@ fn handle_tuple_struct(input: DeriveInput, data: &syn::DataStruct) -> TokenStrea
                 }
             });
 
-            encoded_len_fields.push(generate_field_encoded_len(field, access_expr, tag_u32));
+            let encoded_len_tokens = generate_field_encoded_len(field, access_expr, tag_u32);
+            encoded_len_fields.push(encoded_len_tokens.tokens);
         }
 
         clear_fields.push(generate_field_clear(field, &field_access));
@@ -334,7 +335,8 @@ fn handle_named_struct(input: DeriveInput, data: &syn::DataStruct) -> TokenStrea
                     Ok(())
                 }
             });
-            encoded_len_fields.push(generate_field_encoded_len(field, access_expr, tag_u32));
+            let encoded_len_tokens = generate_field_encoded_len(field, access_expr, tag_u32);
+            encoded_len_fields.push(encoded_len_tokens.tokens);
         }
 
         clear_fields.push(generate_field_clear(field, &field_access));

--- a/examples/proto_gen_example.rs
+++ b/examples/proto_gen_example.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 
-use proto_rs::ProtoExt;
 use proto_rs::proto_message;
 use proto_rs::proto_rpc;
 use tokio_stream::Stream;

--- a/protos/tests/encoding.proto
+++ b/protos/tests/encoding.proto
@@ -31,3 +31,10 @@ message SampleMessage {
   optional SampleEnum optional_mode = 9;
 }
 
+message CollectionsMessage {
+  map<uint32, int64> hash_scores = 1;
+  map<string, NestedMessage> tree_messages = 2;
+  repeated string hash_tags = 3;
+  repeated int32 tree_ids = 4;
+}
+


### PR DESCRIPTION
## Summary
- extend the derive utilities to recognise map and set fields, using them during encode/decode/length generation and fixing clippy warnings around unused bindings
- implement `ProtoExt` for `HashMap`, `BTreeMap`, `HashSet`, and `BTreeSet` and update code generation helpers to treat map/set wrappers like repeated fields where appropriate
- add collection-focused fixtures and roundtrip tests covering the new behaviour and clean up an unused import in the proto generation example

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ecccea3d6483219e71b5e7c20afdff