### PR TITLE
Refactor wrapper traits and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,367 +1,102 @@
-# Rust as first-class citizen for gRPC ecosystem
+# proto_rs
 
-This crate provides 4 macros that will handle all proto-related work, so you don't need to touch .proto files at all.
+`proto_rs` makes Rust the source of truth for your Protobuf and gRPC definitions. The crate ships a set of procedural macros and runtime helpers that derive message encoders/decoders, generate `.proto` files on demand, and wire traits directly into Tonic servers and clients.
 
-## Motivation
+## Key capabilities
 
-0. I hate to do conversion after conversion for conversion
-1. I love to see Rust only as first-class citizen for all my stuff
-2. I hate bloat, so no protoc (shoutout to PewDiePie debloat trend)
-3. I don't want to touch .proto files at all
+- **Message derivation** – `#[proto_message]` turns a Rust struct or enum into a fully featured Protobuf message, emitting the corresponding `.proto` definition and implementing [`ProtoExt`](src/message.rs) so the type can be encoded/decoded without extra glue code.
+- **RPC generation** – `#[proto_rpc]` projects a Rust trait into a complete Tonic service and/or client. Service traits can stay idiomatic while still interoperating with non-Rust consumers through the generated `.proto` artifacts.
+- **On-demand schema dumps** – `proto_dump!` and `inject_proto_import!` let you register standalone definitions or imports when you need to compose more complex schemas.
+- **Workspace-wide schema registry** – With the `build-schemas` feature enabled you can aggregate every proto that was emitted by your dependency tree and write it to disk via [`proto_rs::schemas::write_all`](src/lib.rs).
+- **Opt-in `.proto` emission** – Proto files are written only when you ask for them via the `emit-proto-files` cargo feature or the `PROTO_EMIT_FILE=1` environment variable, making it easy to toggle between codegen and incremental development.
 
-## Usage
+## Getting started
 
-The `#[proto_rpc]` macro will convert your Rust native trait to tonic and optionally emit .proto file:
+Add `proto_rs` to your `Cargo.toml` and optionally enable features you need (for example to eagerly emit `.proto` files during development):
 
-```rust
-#[proto_rpc(rpc_package = "sigma_rpc", rpc_server = true, rpc_client = true, proto_path = "protos/gen_complex_proto/sigma_rpc.proto")]
-#[proto_imports(rizz_types = ["BarSub", "FooResponse"], goon_types = ["RizzPing", "GoonPong"] )]
-pub trait SigmaRpc {
-    type RizzUniStream: Stream<Item = Result<FooResponse, Status>> + Send;
-    async fn rizz_ping(&self, request: Request<RizzPing>) -> Result<Response<GoonPong>, Status>;
-
-    async fn rizz_uni(&self, request: Request<BarSub>) -> Result<Response<Self::RizzUniStream>, Status>;
-}
+```toml
+[dependencies]
+proto_rs = { version = "0.5", features = ["emit-proto-files"] }
+tonic = "0.14"
 ```
 
-Yep, all types here are just Rust types. We can then implement the server like this:
+Define your messages and services using the derive macros:
 
 ```rust
-#[tonic::async_trait]
-impl SigmaRpc for S {
-    type RizzUniStream = Pin<Box<dyn Stream<Item = Result<FooResponse, Status>> + Send>>;
-    async fn rizz_ping(&self, _req: Request<RizzPing>) -> Result<Response<GoonPong>, Status> {
-        Ok(Response::new(GoonPong {}))
-    }
-    async fn rizz_uni(&self, _request: Request<BarSub>) -> Result<Response<Self::RizzUniStream>, Status> {
-        let (tx, rx) = tokio::sync::mpsc::channel(128);
+use proto_rs::{proto_message, proto_rpc};
 
-        tokio::spawn(async move {
-            for _ in 0..5 {
-                if tx.send(Ok(FooResponse {})).await.is_err() {
-                    break;
-                }
-                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            }
-        });
-
-        let stream = ReceiverStream::new(rx);
-        let boxed_stream: Self::RizzUniStream = Box::pin(stream);
-
-        Ok(Response::new(boxed_stream))
-    }
-}
-```
-
-This is possible because of this trait, that handles all conversions automagically:
-
-```rust
-pub trait HasProto {
-    type Proto: prost::Message;
-    fn to_proto(&self) -> Self::Proto;
-    fn from_proto(proto: Self::Proto) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        Self: Sized;
-}
-```
-
-We can derive it (or manually implement) for most types with `#[proto_message]` macro:
-
-```rust
-#[proto_message(proto_path ="protos/gen_proto/goon_types.proto")]
+#[proto_message(proto_path = "protos/gen_proto/rpc.proto")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RizzPing;
+
+#[proto_rpc(
+    rpc_package = "sigma_rpc",
+    rpc_server = true,
+    rpc_client = true,
+    proto_path = "protos/gen_proto/sigma_rpc.proto",
+)]
+pub trait SigmaRpc {
+    type Stream: futures_core::Stream<Item = Result<FooResponse, tonic::Status>> + Send;
+
+    async fn rizz_ping(
+        &self,
+        request: tonic::Request<RizzPing>,
+    ) -> Result<tonic::Response<GoonPong>, tonic::Status>;
+
+    async fn rizz_uni(
+        &self,
+        request: tonic::Request<BarSub>,
+    ) -> Result<tonic::Response<Self::Stream>, tonic::Status>;
+}
 ```
 
-But that's not all — `#[proto_message]` and `#[proto_rpc]` will also create .proto definitions for non-Rust clients.
+Once compiled, the trait can be implemented just like a normal Tonic service, but the `.proto` schema is generated for you whenever emission is enabled.
 
-## Build All .proto Files from Dependencies at once
+## Collecting schemas across a workspace
 
-**Pure Rust Black Magic**
-
-This crate provides a powerful feature to collect and build .proto files from ALL dependencies that use `proto_rs` in a single place. This is incredibly useful for building a centralized proto schema from a multi-crate workspace.
-
-### Usage
-
-In your `build.rs` or `main.rs` (or any crate that has other proto_rs dependent crates):
+Enable the `build-schemas` feature for the crate that should aggregate `.proto` files and call the helper at build or runtime:
 
 ```rust
-use proto_rs::schemas::ProtoSchema;
-
 fn main() {
-    proto_rs::schemas::write_all("build_protos").expect("Failed to write proto files");
-    
-    for schema in inventory::iter::<ProtoSchema> {
-        println!("Collected: {}", schema.name);
+    // Typically gated by an env flag to avoid touching disk unnecessarily.
+    proto_rs::schemas::write_all("./protos")
+        .expect("failed to write generated protos");
+
+    for schema in proto_rs::schemas::all() {
+        println!("Registered proto: {}", schema.name);
     }
 }
 ```
 
-This will automatically collect and build all .proto files from all crates in your dependency tree that use `proto_rs` macros!
+This walks the inventory of registered schemas and writes deduplicated `.proto` files with a canonical header and package name derived from the file path.
 
-## Examples
+## Controlling `.proto` emission
 
-You can see more in examples:
+`proto_rs` will only touch the filesystem when one of the following is set:
 
-- **proto_gen_example** - simple service with streaming (generated .proto saved here: protos/gen_proto)
-- **prosto_proto** - showcase of type possibilities (generated .proto saved here: protos/showcase_proto)
-- **tests/proto_build_test** - example of how you can build .proto files only on demand
+- Enable the `emit-proto-files` cargo feature to always write generated files.
+- Set `PROTO_EMIT_FILE=1` (or `true`) to override the default at runtime.
+- Set `PROTO_EMIT_FILE=0` (or `false`) to force emission off even if the feature is enabled.
 
+The emission logic is shared by all macros so you can switch behaviours without code changes.
 
-## .proto Auto-Emission Control
+## Examples and tests
 
-Controls auto-emission of .proto files by macros:
-- `"emit-proto-files"` - cargo feature
-- `"PROTO_EMIT_FILE"` - env var
+Explore the `examples/` directory and the integration tests under `tests/` for end-to-end usage patterns, including schema-only builds and cross-compatibility checks.
 
-### .proto Auto-Emission Behavior
+To validate changes locally run:
 
-| Feature | Env Var | Result |
-|---------|---------|--------|
-| none | not set | ❌ No emission |
-| none | true | ✅ Emit files |
-| none | false | ❌ No emission |
-| emit-proto-files | not set | ✅ Emit files |
-| emit-proto-files | true | ✅ Emit files |
-| emit-proto-files | false | ❌ No emission (override) |
-| build-schemas | (any) | ✅ Emit const |
-
-## proto_dump for hand-written types
-
-This crate also provides an auxiliary macro `#[proto_dump(proto_path ="protos/proto_dump.proto")]` that outputs a .proto file. This is helpful for hand-written types.
-
-```rust
-#[proto_dump(proto_path ="protos/proto_dump.proto")]
-#[derive(prost::Message, Clone, PartialEq)]
-pub struct LamportsProto {
-    #[prost(uint64, tag = 1)]
-    pub amount: u64,
-}
+```bash
+cargo test
 ```
 
-Generated proto:
+The test suite exercises more than 400 codec and integration scenarios to ensure the derived implementations stay compatible with Prost and Tonic.
 
-```proto
-syntax = "proto3";
-package proto_dump;
+## Optional features
 
-message Lamports {
-    uint64 amount = 1;
-}
-```
+- `build-schemas` – register generated schemas at compile time so they can be written later.
+- `emit-proto-files` – eagerly write `.proto` files during compilation.
+- `fastnum`, `solana` – enable extra type support for domain-specific numbers and Solana primitives.
+- `shadow_gen`, `direct_gen` – forward feature flags to the derive crate for advanced generation modes.
 
-## Inject Proto Imports
-
-It's not mandatory to use this macro at all, macros above derive and inject imports from attributes automaticly
-
-But in case you need it, to add custom imports to your generated .proto files use the `inject_proto_import!` macro:
-
-```rust
-inject_proto_import!("protos/test.proto", "google.protobuf.timestamp", "common");
-```
-
-This will inject the specified import statements into the target .proto file
-
-
-## Advanced Features
-
-Macros support all prost types, imports, skipping with default and custom functions, custom conversions, support for native Rust enums (like `Status` below) and prost enumerations (TestEnum in this example, see more in prosto_proto).
-
-### Struct with Advanced Attributes
-
-```rust
-#[proto_message(proto_path ="protos/showcase_proto/show.proto")]
-pub struct Attr {
-    #[proto(skip)]
-    id_skip: Vec<i64>,
-    id_vec: Vec<String>,
-    id_opt: Option<String>,
-    status: Status,
-    status_opt: Option<Status>,
-    status_vec: Vec<Status>,
-    #[proto(skip = "compute_hash_for_struct")]
-    hash: String,
-    #[proto(import_path = "google.protobuf")]
-    timestamp: Timestamp,
-    #[proto(import_path = "google.protobuf")]
-    timestamp_vec: Vec<Timestamp>,
-    #[proto(import_path = "google.protobuf")]
-    timestamp_opt: Option<Timestamp>,
-    #[proto(enum)]
-    #[proto(import_path = "google.protobuf")]
-    test_enum: TestEnum,
-    #[proto(enum)]
-    #[proto(import_path = "google.protobuf")]
-    test_enum_opt: Option<TestEnum>,
-    #[proto(enum)]
-    #[proto(import_path = "google.protobuf")]
-    test_enum_vec: Vec<TestEnum>,
-    #[proto(into = "i64", into_fn = "datetime_to_i64", from_fn = "i64_to_datetime")]
-    pub updated_at: DateTime<Utc>,
-}
-```
-
-Generated proto:
-
-```proto
-message Attr {
-  repeated string id_vec = 1;
-  optional string id_opt = 2;
-  Status status = 3;
-  optional Status status_opt = 4;
-  repeated Status status_vec = 5;
-  google.protobuf.Timestamp timestamp = 6;
-  repeated google.protobuf.Timestamp timestamp_vec = 7;
-  optional google.protobuf.Timestamp timestamp_opt = 8;
-  google.protobuf.TestEnum test_enum = 9;
-  optional google.protobuf.TestEnum test_enum_opt = 10;
-  repeated google.protobuf.TestEnum test_enum_vec = 11;
-  int64 updated_at = 12;
-}
-```
-
-### Complex Enums
-
-```rust
-#[proto_message(proto_path ="protos/showcase_proto/show.proto")]
-pub enum VeryComplex {
-    First,
-    Second(Address),
-    Third {
-        id: u64,
-        address: Address,
-    },
-    Repeated {
-        id: Vec<u64>,
-        address: Vec<Address>,
-    },
-    Option {
-        id: Option<u64>,
-        address: Option<Address>,
-    },
-    Attr {
-        #[proto(skip)]
-        id_skip: Vec<i64>,
-        id_vec: Vec<String>,
-        id_opt: Option<String>,
-        status: Status,
-        status_opt: Option<Status>,
-        status_vec: Vec<Status>,
-        #[proto(skip = "compute_hash_for_enum")]
-        hash: String,
-        #[proto(import_path = "google.protobuf")]
-        timestamp: Timestamp,
-        #[proto(import_path = "google.protobuf")]
-        timestamp_vec: Vec<Timestamp>,
-        #[proto(import_path = "google.protobuf")]
-        timestamp_opt: Option<Timestamp>,
-        #[proto(enum)]
-        #[proto(import_path = "google.protobuf")]
-        test_enum: TestEnum,
-        #[proto(enum)]
-        #[proto(import_path = "google.protobuf")]
-        test_enum_opt: Option<TestEnum>,
-        #[proto(enum)]
-        #[proto(import_path = "google.protobuf")]
-        test_enum_vec: Vec<TestEnum>,
-    },
-}
-```
-
-Generated proto:
-
-```proto
-message VeryComplexProto {
-  oneof value {
-    VeryComplexProtoFirst first = 1;
-    Address second = 2;
-    VeryComplexProtoThird third = 3;
-    VeryComplexProtoRepeated repeated = 4;
-    VeryComplexProtoOption option = 5;
-    VeryComplexProtoAttr attr = 6;
-  }
-}
-
-message VeryComplexProtoFirst {}
-
-message VeryComplexProtoThird {
-  uint64 id = 1;
-  Address address = 2;
-}
-
-message VeryComplexProtoRepeated {
-  repeated uint64 id = 1;
-  repeated Address address = 2;
-}
-
-message VeryComplexProtoOption {
-  optional uint64 id = 1;
-  optional Option address = 2;
-}
-
-message VeryComplexProtoAttr {
-  repeated string id_vec = 1;
-  optional string id_opt = 2;
-  Status status = 3;
-  optional Status status_opt = 4;
-  repeated Status status_vec = 5;
-  google.protobuf.Timestamp timestamp = 6;
-  repeated google.protobuf.Timestamp timestamp_vec = 7;
-  optional google.protobuf.Timestamp timestamp_opt = 8;
-  google.protobuf.TestEnum test_enum = 9;
-  optional google.protobuf.TestEnum test_enum_opt = 10;
-  repeated google.protobuf.TestEnum test_enum_vec = 11;
-}
-```
-
-### Simple Rust Enum
-
-```rust
-#[proto_message(proto_path ="protos/showcase_proto/show.proto")]
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub enum Status {
-    Pending,
-    #[default]
-    Active,
-    Inactive,
-    Completed,
-}
-```
-
-Generated proto:
-
-```proto
-enum Status {
-  PENDING = 0;
-  ACTIVE = 1;
-  INACTIVE = 2;
-  COMPLETED = 3;
-}
-```
-
-## Dependencies
-
-Crate pulled dependencies:
-
-```
-01:04:53 ➜ cargo tree
-proto_rs v0.2.0
-├── prost v0.14.1
-│   ├── bytes v1.10.1
-│   └── prost-derive v0.14.1 (proc-macro)
-│       ├── anyhow v1.0.100
-│       ├── itertools v0.14.0
-│       │   └── either v1.15.0
-│       ├── proc-macro2 v1.0.101
-│       │   └── unicode-ident v1.0.19
-│       ├── quote v1.0.41
-│       │   └── proc-macro2 v1.0.101 (*)
-│       └── syn v2.0.106
-│           ├── proc-macro2 v1.0.101 (*)
-│           ├── quote v1.0.41 (*)
-│           └── unicode-ident v1.0.19
-└── prosto_derive v0.2.0 (proc-macro) 
-    ├── proc-macro2 v1.0.101 (*)
-    ├── quote v1.0.41 (*)
-    └── syn v2.0.106 (*)
-```
+For the full API surface and macro documentation see [docs.rs/proto_rs](https://docs.rs/proto_rs).

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,701 +32,109 @@ use crate::encoding::uint32;
 use crate::encoding::uint64;
 use crate::encoding::wire_type::WireType;
 
-/// `google.protobuf.BoolValue`
-impl ProtoExt for bool {
-    #[inline]
-    fn proto_default() -> Self {
-        false
-    }
+macro_rules! impl_google_wrapper {
+    ($ty:ty, $module:ident, $name:literal, |$value:ident| $is_default:expr, |$clear_value:ident| $clear_body:expr) => {
+        impl ProtoExt for $ty {
+            #[inline]
+            fn proto_default() -> Self {
+                Default::default()
+            }
 
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self {
-            bool::encode(1, self, buf)
+            fn encode_raw(&self, buf: &mut impl BufMut) {
+                if !{
+                    let $value: &$ty = self;
+                    $is_default
+                } {
+                    $module::encode(1, self, buf);
+                }
+            }
+
+            fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
+                if tag == 1 {
+                    $module::merge(wire_type, self, buf, ctx)
+                } else {
+                    skip_field(wire_type, tag, buf, ctx)
+                }
+            }
+
+            fn encoded_len(&self) -> usize {
+                if {
+                    let $value: &$ty = self;
+                    $is_default
+                } {
+                    0
+                } else {
+                    $module::encoded_len(1, self)
+                }
+            }
+
+            fn clear(&mut self) {
+                let $clear_value: &mut $ty = self;
+                $clear_body
+            }
         }
-    }
 
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 { bool::merge(wire_type, self, buf, ctx) } else { skip_field(wire_type, tag, buf, ctx) }
-    }
+        impl Name for $ty {
+            const NAME: &'static str = $name;
+            const PACKAGE: &'static str = "google.protobuf";
 
-    fn encoded_len(&self) -> usize {
-        if *self { 2 } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = false;
-    }
-}
-
-/// `google.protobuf.BoolValue`
-impl Name for bool {
-    const NAME: &'static str = "BoolValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for bool {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        bool::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bool::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        bool::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for bool {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value {
-            bool::encode(tag, value, buf);
+            fn type_url() -> String {
+                googleapis_type_url_for::<Self>()
+            }
         }
-    }
 
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bool::merge(wire_type, value, buf, ctx)
-    }
+        impl RepeatedField for $ty {
+            fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
+                $module::encode_repeated(tag, values, buf);
+            }
 
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value { bool::encoded_len(tag, value) } else { 0 }
-    }
-}
+            fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
+                $module::merge_repeated(wire_type, values, buf, ctx)
+            }
 
-/// `google.protobuf.UInt32Value`
-impl ProtoExt for u32 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            uint32::encode(1, self, buf)
+            fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
+                $module::encoded_len_repeated(tag, values)
+            }
         }
-    }
 
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            uint32::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
+        impl SingularField for $ty {
+            fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
+                if !{
+                    let $value: &$ty = value;
+                    $is_default
+                } {
+                    $module::encode(tag, value, buf);
+                }
+            }
+
+            fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
+                $module::merge(wire_type, value, buf, ctx)
+            }
+
+            fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
+                if {
+                    let $value: &$ty = value;
+                    $is_default
+                } {
+                    0
+                } else {
+                    $module::encoded_len(tag, value)
+                }
+            }
         }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { uint32::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
+    };
 }
 
-/// `google.protobuf.UInt32Value`
-impl Name for u32 {
-    const NAME: &'static str = "UInt32Value";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for u32 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        uint32::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        uint32::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        uint32::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for u32 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            uint32::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        uint32::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0 { uint32::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.UInt64Value`
-impl ProtoExt for u64 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            uint64::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            uint64::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { uint64::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-/// `google.protobuf.UInt64Value`
-impl Name for u64 {
-    const NAME: &'static str = "UInt64Value";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for u64 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        uint64::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        uint64::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        uint64::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for u64 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            uint64::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        uint64::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0 { uint64::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.Int32Value`
-impl ProtoExt for i32 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            int32::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            int32::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { int32::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-/// `google.protobuf.Int32Value`
-impl Name for i32 {
-    const NAME: &'static str = "Int32Value";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for i32 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        int32::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        int32::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        int32::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for i32 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            int32::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        int32::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0 { int32::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.Int64Value`
-impl ProtoExt for i64 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            int64::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            int64::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { int64::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-/// `google.protobuf.Int64Value`
-impl Name for i64 {
-    const NAME: &'static str = "Int64Value";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for i64 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        int64::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        int64::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        int64::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for i64 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            int64::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        int64::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0 { int64::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.FloatValue`
-impl ProtoExt for f32 {
-    #[inline]
-    fn proto_default() -> Self {
-        0.0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0.0 {
-            float::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            float::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0.0 { float::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0.0;
-    }
-}
-
-/// `google.protobuf.FloatValue`
-impl Name for f32 {
-    const NAME: &'static str = "FloatValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for f32 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        float::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        float::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        float::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for f32 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0.0 {
-            float::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        float::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0.0 { float::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.DoubleValue`
-impl ProtoExt for f64 {
-    #[inline]
-    fn proto_default() -> Self {
-        0.0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0.0 {
-            double::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            double::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0.0 { double::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0.0;
-    }
-}
-
-/// `google.protobuf.DoubleValue`
-impl Name for f64 {
-    const NAME: &'static str = "DoubleValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for f64 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        double::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        double::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        double::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for f64 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0.0 {
-            double::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        double::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value != 0.0 { double::encoded_len(tag, value) } else { 0 }
-    }
-}
-
-/// `google.protobuf.StringValue`
-impl ProtoExt for String {
-    #[inline]
-    fn proto_default() -> Self {
-        String::new()
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if !self.is_empty() {
-            string::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            string::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if !self.is_empty() { string::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        self.clear();
-    }
-}
-
-/// `google.protobuf.StringValue`
-impl Name for String {
-    const NAME: &'static str = "StringValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for String {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        string::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        string::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        string::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for String {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if !value.is_empty() {
-            string::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        string::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if value.is_empty() { 0 } else { string::encoded_len(tag, value) }
-    }
-}
-
-/// `google.protobuf.BytesValue`
-impl ProtoExt for Vec<u8> {
-    #[inline]
-    fn proto_default() -> Self {
-        Vec::new()
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if !self.is_empty() {
-            bytes::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            bytes::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if !self.is_empty() { bytes::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        self.clear();
-    }
-}
-
-/// `google.protobuf.BytesValue`
-impl Name for Vec<u8> {
-    const NAME: &'static str = "BytesValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for Vec<u8> {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        bytes::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bytes::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        bytes::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for Vec<u8> {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if !value.is_empty() {
-            bytes::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bytes::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if value.is_empty() { 0 } else { bytes::encoded_len(tag, value) }
-    }
-}
-
-/// `google.protobuf.BytesValue`
-impl ProtoExt for Bytes {
-    #[inline]
-    fn proto_default() -> Self {
-        Bytes::new()
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if !self.is_empty() {
-            bytes::encode(1, self, buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            bytes::merge(wire_type, self, buf, ctx)
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if !self.is_empty() { bytes::encoded_len(1, self) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        self.clear();
-    }
-}
-
-/// `google.protobuf.BytesValue`
-impl Name for Bytes {
-    const NAME: &'static str = "BytesValue";
-    const PACKAGE: &'static str = "google.protobuf";
-
-    fn type_url() -> String {
-        googleapis_type_url_for::<Self>()
-    }
-}
-
-impl RepeatedField for Bytes {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        bytes::encode_repeated(tag, values, buf);
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bytes::merge_repeated(wire_type, values, buf, ctx)
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        bytes::encoded_len_repeated(tag, values)
-    }
-}
-
-impl SingularField for Bytes {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if !value.is_empty() {
-            bytes::encode(tag, value, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        bytes::merge(wire_type, value, buf, ctx)
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if value.is_empty() { 0 } else { bytes::encoded_len(tag, value) }
-    }
-}
+impl_google_wrapper!(bool, bool, "BoolValue", |value| !*value, |value| *value = false);
+impl_google_wrapper!(u32, uint32, "UInt32Value", |value| *value == 0, |value| *value = 0);
+impl_google_wrapper!(u64, uint64, "UInt64Value", |value| *value == 0, |value| *value = 0);
+impl_google_wrapper!(i32, int32, "Int32Value", |value| *value == 0, |value| *value = 0);
+impl_google_wrapper!(i64, int64, "Int64Value", |value| *value == 0, |value| *value = 0);
+impl_google_wrapper!(f32, float, "FloatValue", |value| *value == 0.0, |value| *value = 0.0);
+impl_google_wrapper!(f64, double, "DoubleValue", |value| *value == 0.0, |value| *value = 0.0);
+impl_google_wrapper!(String, string, "StringValue", |value| value.is_empty(), |value| value.clear());
+impl_google_wrapper!(Vec<u8>, bytes, "BytesValue", |value| value.is_empty(), |value| value.clear());
+impl_google_wrapper!(Bytes, bytes, "BytesValue", |value| value.is_empty(), |value| value.clear());
 
 /// `google.protobuf.Empty`
 impl ProtoExt for () {
@@ -767,345 +175,139 @@ fn googleapis_type_url_for<T: Name>() -> String {
 // Additional implementations for smaller primitive types
 // These are not part of protobuf well-known types but needed for internal use
 
-/// Internal implementation for u8
-impl ProtoExt for u8 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
+macro_rules! impl_narrow_varint {
+    ($ty:ty, $wide_ty:ty, $module:ident, $err:literal) => {
+        impl_narrow_varint!(@impl $ty, $wide_ty, $module, $err, true);
+    };
+    ($ty:ty, $wide_ty:ty, $module:ident, $err:literal, no_repeated) => {
+        impl_narrow_varint!(@impl $ty, $wide_ty, $module, $err, false);
+    };
+    (@impl $ty:ty, $wide_ty:ty, $module:ident, $err:literal, $with_repeated:tt) => {
+        impl ProtoExt for $ty {
+            #[inline]
+            fn proto_default() -> Self {
+                Self::default()
+            }
 
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            uint32::encode(1, &(*self as u32), buf)
+            fn encode_raw(&self, buf: &mut impl BufMut) {
+                if *self != Self::default() {
+                    let widened: $wide_ty = (*self).into();
+                    $module::encode(1, &widened, buf);
+                }
+            }
+
+            fn merge_field(
+                &mut self,
+                tag: u32,
+                wire_type: WireType,
+                buf: &mut impl Buf,
+                ctx: DecodeContext,
+            ) -> Result<(), DecodeError> {
+                if tag == 1 {
+                    let mut widened: $wide_ty = <$wide_ty as Default>::default();
+                    $module::merge(wire_type, &mut widened, buf, ctx)?;
+                    *self = widened.try_into().map_err(|_| DecodeError::new($err))?;
+                    Ok(())
+                } else {
+                    skip_field(wire_type, tag, buf, ctx)
+                }
+            }
+
+            fn encoded_len(&self) -> usize {
+                if *self == Self::default() {
+                    0
+                } else {
+                    let widened: $wide_ty = (*self).into();
+                    $module::encoded_len(1, &widened)
+                }
+            }
+
+            fn clear(&mut self) {
+                *self = Self::default();
+            }
         }
-    }
 
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            let mut temp: u32 = 0;
-            uint32::merge(wire_type, &mut temp, buf, ctx)?;
-            *self = temp.try_into().map_err(|_| DecodeError::new("u8 overflow"))?;
-            Ok(())
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
+        impl SingularField for $ty {
+            fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
+                if *value != Self::default() {
+                    let widened: $wide_ty = (*value).into();
+                    $module::encode(tag, &widened, buf);
+                }
+            }
 
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { uint32::encoded_len(1, &(*self as u32)) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-impl SingularField for u8 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            let converted: u32 = (*value).into();
-            uint32::encode(tag, &converted, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        let mut temp: u32 = 0;
-        uint32::merge(wire_type, &mut temp, buf, ctx)?;
-        *value = temp.try_into().map_err(|_| DecodeError::new("u8 overflow"))?;
-        Ok(())
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value == 0 {
-            0
-        } else {
-            let converted: u32 = (*value).into();
-            uint32::encoded_len(tag, &converted)
-        }
-    }
-}
-
-/// Internal implementation for u16
-impl ProtoExt for u16 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            uint32::encode(1, &(*self as u32), buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            let mut temp: u32 = 0;
-            uint32::merge(wire_type, &mut temp, buf, ctx)?;
-            *self = temp.try_into().map_err(|_| DecodeError::new("u16 overflow"))?;
-            Ok(())
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { uint32::encoded_len(1, &(*self as u32)) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-impl SingularField for u16 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            let converted: u32 = (*value).into();
-            uint32::encode(tag, &converted, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        let mut temp: u32 = 0;
-        uint32::merge(wire_type, &mut temp, buf, ctx)?;
-        *value = temp.try_into().map_err(|_| DecodeError::new("u16 overflow"))?;
-        Ok(())
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value == 0 {
-            0
-        } else {
-            let converted: u32 = (*value).into();
-            uint32::encoded_len(tag, &converted)
-        }
-    }
-}
-
-impl RepeatedField for u16 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        for value in values {
-            let widened = u32::from(*value);
-            uint32::encode(tag, &widened, buf);
-        }
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if wire_type == WireType::LengthDelimited {
-            crate::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
-                let mut widened: u32 = 0;
-                uint32::merge(WireType::Varint, &mut widened, buf, ctx)?;
-                values.push(widened.try_into().map_err(|_| DecodeError::new("u16 overflow"))?);
+            fn merge_singular_field(
+                wire_type: WireType,
+                value: &mut Self,
+                buf: &mut impl Buf,
+                ctx: DecodeContext,
+            ) -> Result<(), DecodeError> {
+                let mut widened: $wide_ty = <$wide_ty as Default>::default();
+                $module::merge(wire_type, &mut widened, buf, ctx)?;
+                *value = widened.try_into().map_err(|_| DecodeError::new($err))?;
                 Ok(())
-            })
-        } else {
-            crate::encoding::check_wire_type(WireType::Varint, wire_type)?;
-            let mut widened: u32 = 0;
-            uint32::merge(wire_type, &mut widened, buf, ctx)?;
-            values.push(widened.try_into().map_err(|_| DecodeError::new("u16 overflow"))?);
-            Ok(())
-        }
-    }
+            }
 
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        values
-            .iter()
-            .map(|value| {
-                let widened = u32::from(*value);
-                uint32::encoded_len(tag, &widened)
-            })
-            .sum()
-    }
+            fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
+                if *value == Self::default() {
+                    0
+                } else {
+                    let widened: $wide_ty = (*value).into();
+                    $module::encoded_len(tag, &widened)
+                }
+            }
+        }
+
+        impl_narrow_varint!(@maybe_repeated $with_repeated, $ty, $wide_ty, $module, $err);
+    };
+    (@maybe_repeated true, $ty:ty, $wide_ty:ty, $module:ident, $err:literal) => {
+        impl RepeatedField for $ty {
+            fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
+                for value in values {
+                    let widened: $wide_ty = (*value).into();
+                    $module::encode(tag, &widened, buf);
+                }
+            }
+
+            fn merge_repeated_field(
+                wire_type: WireType,
+                values: &mut Vec<Self>,
+                buf: &mut impl Buf,
+                ctx: DecodeContext,
+            ) -> Result<(), DecodeError> {
+                if wire_type == WireType::LengthDelimited {
+                    crate::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
+                        let mut widened: $wide_ty = <$wide_ty as Default>::default();
+                        $module::merge(WireType::Varint, &mut widened, buf, ctx)?;
+                        values.push(widened.try_into().map_err(|_| DecodeError::new($err))?);
+                        Ok(())
+                    })
+                } else {
+                    crate::encoding::check_wire_type(WireType::Varint, wire_type)?;
+                    let mut widened: $wide_ty = <$wide_ty as Default>::default();
+                    $module::merge(wire_type, &mut widened, buf, ctx)?;
+                    values.push(widened.try_into().map_err(|_| DecodeError::new($err))?);
+                    Ok(())
+                }
+            }
+
+            fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
+                values
+                    .iter()
+                    .map(|value| {
+                        let widened: $wide_ty = (*value).into();
+                        $module::encoded_len(tag, &widened)
+                    })
+                    .sum()
+            }
+        }
+    };
+    (@maybe_repeated false, $ty:ty, $wide_ty:ty, $module:ident, $err:literal) => {};
 }
 
-/// Internal implementation for i8
-impl ProtoExt for i8 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            int32::encode(1, &(*self as i32), buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            let mut temp: i32 = 0;
-            int32::merge(wire_type, &mut temp, buf, ctx)?;
-            *self = temp.try_into().map_err(|_| DecodeError::new("i8 overflow"))?;
-            Ok(())
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { int32::encoded_len(1, &(*self as i32)) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-impl SingularField for i8 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            let converted: i32 = (*value).into();
-            int32::encode(tag, &converted, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        let mut temp: i32 = 0;
-        int32::merge(wire_type, &mut temp, buf, ctx)?;
-        *value = temp.try_into().map_err(|_| DecodeError::new("i8 overflow"))?;
-        Ok(())
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value == 0 {
-            0
-        } else {
-            let converted: i32 = (*value).into();
-            int32::encoded_len(tag, &converted)
-        }
-    }
-}
-
-impl RepeatedField for i8 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        for value in values {
-            let widened = i32::from(*value);
-            int32::encode(tag, &widened, buf);
-        }
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if wire_type == WireType::LengthDelimited {
-            crate::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
-                let mut widened: i32 = 0;
-                int32::merge(WireType::Varint, &mut widened, buf, ctx)?;
-                values.push(widened.try_into().map_err(|_| DecodeError::new("i8 overflow"))?);
-                Ok(())
-            })
-        } else {
-            crate::encoding::check_wire_type(WireType::Varint, wire_type)?;
-            let mut widened: i32 = 0;
-            int32::merge(wire_type, &mut widened, buf, ctx)?;
-            values.push(widened.try_into().map_err(|_| DecodeError::new("i8 overflow"))?);
-            Ok(())
-        }
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        values
-            .iter()
-            .map(|value| {
-                let widened = i32::from(*value);
-                int32::encoded_len(tag, &widened)
-            })
-            .sum()
-    }
-}
-
-/// Internal implementation for i16
-impl ProtoExt for i16 {
-    #[inline]
-    fn proto_default() -> Self {
-        0
-    }
-
-    fn encode_raw(&self, buf: &mut impl BufMut) {
-        if *self != 0 {
-            int32::encode(1, &(*self as i32), buf)
-        }
-    }
-
-    fn merge_field(&mut self, tag: u32, wire_type: WireType, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if tag == 1 {
-            let mut temp: i32 = 0;
-            int32::merge(wire_type, &mut temp, buf, ctx)?;
-            *self = temp.try_into().map_err(|_| DecodeError::new("i16 overflow"))?;
-            Ok(())
-        } else {
-            skip_field(wire_type, tag, buf, ctx)
-        }
-    }
-
-    fn encoded_len(&self) -> usize {
-        if *self != 0 { int32::encoded_len(1, &(*self as i32)) } else { 0 }
-    }
-
-    fn clear(&mut self) {
-        *self = 0;
-    }
-}
-
-impl SingularField for i16 {
-    fn encode_singular_field(tag: u32, value: &Self, buf: &mut impl BufMut) {
-        if *value != 0 {
-            let converted: i32 = (*value).into();
-            int32::encode(tag, &converted, buf);
-        }
-    }
-
-    fn merge_singular_field(wire_type: WireType, value: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        let mut temp: i32 = 0;
-        int32::merge(wire_type, &mut temp, buf, ctx)?;
-        *value = temp.try_into().map_err(|_| DecodeError::new("i16 overflow"))?;
-        Ok(())
-    }
-
-    fn encoded_len_singular_field(tag: u32, value: &Self) -> usize {
-        if *value == 0 {
-            0
-        } else {
-            let converted: i32 = (*value).into();
-            int32::encoded_len(tag, &converted)
-        }
-    }
-}
-
-impl RepeatedField for i16 {
-    fn encode_repeated_field(tag: u32, values: &[Self], buf: &mut impl BufMut) {
-        for value in values {
-            let widened = i32::from(*value);
-            int32::encode(tag, &widened, buf);
-        }
-    }
-
-    fn merge_repeated_field(wire_type: WireType, values: &mut Vec<Self>, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
-        if wire_type == WireType::LengthDelimited {
-            crate::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
-                let mut widened: i32 = 0;
-                int32::merge(WireType::Varint, &mut widened, buf, ctx)?;
-                values.push(widened.try_into().map_err(|_| DecodeError::new("i16 overflow"))?);
-                Ok(())
-            })
-        } else {
-            crate::encoding::check_wire_type(WireType::Varint, wire_type)?;
-            let mut widened: i32 = 0;
-            int32::merge(wire_type, &mut widened, buf, ctx)?;
-            values.push(widened.try_into().map_err(|_| DecodeError::new("i16 overflow"))?);
-            Ok(())
-        }
-    }
-
-    fn encoded_len_repeated_field(tag: u32, values: &[Self]) -> usize {
-        values
-            .iter()
-            .map(|value| {
-                let widened = i32::from(*value);
-                int32::encoded_len(tag, &widened)
-            })
-            .sum()
-    }
-}
+impl_narrow_varint!(u8, u32, uint32, "u8 overflow", no_repeated);
+impl_narrow_varint!(u16, u32, uint32, "u16 overflow");
+impl_narrow_varint!(i8, i32, int32, "i8 overflow");
+impl_narrow_varint!(i16, i32, int32, "i16 overflow");
 
 /// Generic implementation for Option<T>
 impl<T: ProtoExt> ProtoExt for Option<T> {


### PR DESCRIPTION
## Summary
- replace large hand-written wrapper trait impls with reusable macros and shared helper logic
- add optional repeated-field support for narrow integer wrappers and avoid redundant Vec<u8> impl conflicts
- rewrite the README to document the current feature set, schema registry, and emission controls

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68eceb02018883218d30a42ef1a55481