### PR TITLE
Refine fastnum ProtoExt and add Solana tests

### DIFF
--- a/crates/prosto_derive/src/emit_proto.rs
+++ b/crates/prosto_derive/src/emit_proto.rs
@@ -174,7 +174,9 @@ fn generate_named_fields(fields: &syn::punctuated::Punctuated<syn::Field, syn::t
             ""
         };
 
-        proto_fields.push(format!("  {modifier}{proto_type} {field_name} = {field_num};"));
+        let tag = config.custom_tag.unwrap_or(field_num);
+
+        proto_fields.push(format!("  {modifier}{proto_type} {field_name} = {tag};"));
     }
 
     proto_fields.join("\n")

--- a/src/custom_types/fastnum/unsigned.rs
+++ b/src/custom_types/fastnum/unsigned.rs
@@ -18,39 +18,159 @@ pub struct UD128Proto {
     pub fractional_digits_count: i32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UD128Parts {
+    lo: u64,
+    hi: u64,
+    fractional_digits_count: i32,
+}
+
+impl From<&UD128> for UD128Parts {
+    fn from(value: &UD128) -> Self {
+        let digits: u128 = value
+            .digits()
+            .try_into()
+            .expect("UD128 should have at most u128 digits");
+        Self {
+            lo: digits as u64,
+            hi: (digits >> 64) as u64,
+            fractional_digits_count: value.fractional_digits_count() as i32,
+        }
+    }
+}
+
+impl From<UD128> for UD128Parts {
+    fn from(value: UD128) -> Self {
+        Self::from(&value)
+    }
+}
+
+impl From<UD128Parts> for UD128Proto {
+    fn from(parts: UD128Parts) -> Self {
+        Self {
+            lo: parts.lo,
+            hi: parts.hi,
+            fractional_digits_count: parts.fractional_digits_count,
+        }
+    }
+}
+
+impl From<UD128Proto> for UD128Parts {
+    fn from(proto: UD128Proto) -> Self {
+        Self {
+            lo: proto.lo,
+            hi: proto.hi,
+            fractional_digits_count: proto.fractional_digits_count,
+        }
+    }
+}
+
+impl UD128Parts {
+    fn into_value(self) -> Result<UD128, crate::DecodeError> {
+        let digits = ((self.hi as u128) << 64) | u128::from(self.lo);
+        let mut value = UD128::from_u128(digits)
+            .map_err(|err| crate::DecodeError::new(err.to_string()))?;
+
+        match self.fractional_digits_count.cmp(&0) {
+            core::cmp::Ordering::Greater => {
+                let divisor = UD128::TEN.powi(self.fractional_digits_count);
+                value /= divisor;
+            }
+            core::cmp::Ordering::Less => {
+                let multiplier = UD128::TEN.powi(-self.fractional_digits_count);
+                value *= multiplier;
+            }
+            core::cmp::Ordering::Equal => {}
+        }
+
+        Ok(value)
+    }
+}
+
 impl HasProto for UD128 {
     type Proto = UD128Proto;
 
     fn to_proto(&self) -> Self::Proto {
-        let digits: u128 = self.digits().try_into().expect("Should be safe as UD128 should have u128 capacity");
-        let lo = digits as u64;
-        let hi = (digits >> 64) as u64;
-        let fractional_digits_count = self.fractional_digits_count() as i32;
-        UD128Proto { lo, hi, fractional_digits_count }
+        UD128Parts::from(self).into()
     }
 
     fn from_proto(proto: Self::Proto) -> Result<Self, Box<dyn std::error::Error>>
     where
         Self: Sized,
     {
-        // Reconstruct u128 from two u64 parts
-        let digits = ((proto.hi as u128) << 64) | (proto.lo as u128);
-
-        // Create UD128 from digits and fractional count
-        // Value = digits * 10^(-fractional_digits_count)
-
-        let mut result = UD128::from_u128(digits)?;
-
-        if proto.fractional_digits_count > 0 {
-            // Use UD128 for the power to avoid overflow
-            let divisor = UD128::TEN.powi(proto.fractional_digits_count);
-            result /= divisor;
-        } else if proto.fractional_digits_count < 0 {
-            let multiplier = UD128::TEN.powi(-proto.fractional_digits_count);
-            result *= multiplier;
-        }
-        Ok(result)
+        UD128Parts::from(proto)
+            .into_value()
+            .map_err(|err| err.to_string().into())
     }
+}
+
+impl crate::ProtoExt for UD128 {
+    fn proto_default() -> Self
+    where
+        Self: Sized,
+    {
+        UD128::ZERO
+    }
+
+    fn encode_raw(&self, buf: &mut impl bytes::BufMut)
+    where
+        Self: Sized,
+    {
+        let parts = UD128Parts::from(self);
+        crate::encoding::uint64::encode(1, &parts.lo, buf);
+        crate::encoding::uint64::encode(2, &parts.hi, buf);
+        crate::encoding::int32::encode(3, &parts.fractional_digits_count, buf);
+    }
+
+    fn merge_field(
+        &mut self,
+        tag: u32,
+        wire_type: crate::encoding::WireType,
+        buf: &mut impl bytes::Buf,
+        ctx: crate::encoding::DecodeContext,
+    ) -> Result<(), crate::DecodeError>
+    where
+        Self: Sized,
+    {
+        let mut parts = UD128Parts::from(&*self);
+        let handled = match tag {
+            1 => {
+                crate::encoding::uint64::merge(wire_type, &mut parts.lo, buf, ctx)?;
+                true
+            }
+            2 => {
+                crate::encoding::uint64::merge(wire_type, &mut parts.hi, buf, ctx)?;
+                true
+            }
+            3 => {
+                crate::encoding::int32::merge(wire_type, &mut parts.fractional_digits_count, buf, ctx)?;
+                true
+            }
+            _ => false,
+        };
+
+        if handled {
+            *self = parts.into_value()?;
+            Ok(())
+        } else {
+            crate::encoding::skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        let parts = UD128Parts::from(self);
+        crate::encoding::uint64::encoded_len(1, &parts.lo)
+            + crate::encoding::uint64::encoded_len(2, &parts.hi)
+            + crate::encoding::int32::encoded_len(3, &parts.fractional_digits_count)
+    }
+
+    fn clear(&mut self) {
+        *self = UD128::ZERO;
+    }
+}
+
+fn ud128_from_proto(proto: UD128Proto) -> Result<UD128, crate::DecodeError> {
+    UD128Parts::from(proto).into_value()
 }
 
 #[cfg(test)]

--- a/src/custom_types/solana/address.rs
+++ b/src/custom_types/solana/address.rs
@@ -8,7 +8,42 @@ extern crate self as proto_rs;
 
 #[proto_dump(proto_path = "protos/solana.proto")]
 struct AddressProto {
+    #[proto(tag = 1)]
     inner: [u8; BYTES],
 }
 
 impl_protoext_for_byte_array!(ByteSeq, BYTES);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::{encode_key, encode_varint, WireType};
+    use crate::ProtoExt;
+
+    fn sample_address_bytes() -> [u8; BYTES] {
+        let mut data = [0u8; BYTES];
+        for (idx, byte) in data.iter_mut().enumerate() {
+            *byte = (idx as u8).wrapping_mul(3).wrapping_add(7);
+        }
+        data
+    }
+
+    #[test]
+    fn roundtrip_proto_ext() {
+        let original = ByteSeq::from(sample_address_bytes());
+        let encoded = <ByteSeq as ProtoExt>::encode_to_vec(&original);
+        let decoded = <ByteSeq as ProtoExt>::decode(encoded.as_slice()).expect("decode");
+        assert_eq!(decoded.as_ref(), original.as_ref());
+    }
+
+    #[test]
+    fn rejects_incorrect_length() {
+        let mut buf = Vec::new();
+        encode_key(1, WireType::LengthDelimited, &mut buf);
+        encode_varint((BYTES - 1) as u64, &mut buf);
+        buf.extend(std::iter::repeat(0u8).take(BYTES - 1));
+
+        let err = <ByteSeq as ProtoExt>::decode(buf.as_slice()).expect_err("invalid length should fail");
+        assert!(err.to_string().contains("expected"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow `#[proto(tag = ...)]` attributes to control `proto_dump` field numbers
- implement `ProtoExt` for the custom fastnum and Solana types so they encode/decode directly, with refined fastnum conversions to avoid redundant state rebuilding
- add roundtrip coverage for Solana byte-array types to ensure ProtoExt stays correct

## Testing
- cargo test --features fastnum,solana

------
https://chatgpt.com/codex/tasks/task_e_68ed04d5903c8321aeec9ed3a67fa369