### PR TITLE
Strip proto attributes from proto_dump output

### DIFF
--- a/crates/prosto_derive/src/proto_dump.rs
+++ b/crates/prosto_derive/src/proto_dump.rs
@@ -1,5 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::Attribute;
 use syn::Data;
 use syn::DeriveInput;
 use syn::Fields;
@@ -27,7 +28,7 @@ pub fn proto_dump_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     panic!("proto_dump can only be used on structs, enums, or traits (services)");
 }
 
-fn struct_or_enum(input: DeriveInput, mut config: UnifiedProtoConfig) -> TokenStream {
+fn struct_or_enum(mut input: DeriveInput, mut config: UnifiedProtoConfig) -> TokenStream {
     let proto_name = input.ident.to_string();
     let clean_name = proto_name.strip_suffix("Proto").unwrap_or(&proto_name);
 
@@ -45,6 +46,7 @@ fn struct_or_enum(input: DeriveInput, mut config: UnifiedProtoConfig) -> TokenSt
     };
 
     config.register_and_emit_proto(clean_name, &proto_def);
+    strip_proto_attributes(&mut input.data);
     let proto = config.imports_mat;
     quote! {
         #input
@@ -53,16 +55,77 @@ fn struct_or_enum(input: DeriveInput, mut config: UnifiedProtoConfig) -> TokenSt
     .into()
 }
 
-fn trait_service(input: ItemTrait, mut config: UnifiedProtoConfig) -> TokenStream {
+fn trait_service(mut input: ItemTrait, mut config: UnifiedProtoConfig) -> TokenStream {
     let proto_name = input.ident.to_string();
     let clean_name = proto_name.strip_suffix("Proto").unwrap_or(&proto_name);
     let (methods, _) = extract_methods_and_types(&input);
     let proto_def = generate_service_content(&input.ident, &methods, &config.type_imports);
     config.register_and_emit_proto(clean_name, &proto_def);
+    strip_proto_attributes_from_trait(&mut input);
     let proto = config.imports_mat;
     quote! {
         #input
         #proto
     }
     .into()
+}
+
+fn strip_proto_attributes(data: &mut Data) {
+    match data {
+        Data::Struct(data) => strip_proto_from_fields(&mut data.fields),
+        Data::Enum(data) => {
+            for variant in &mut data.variants {
+                strip_proto_from_attrs(&mut variant.attrs);
+                strip_proto_from_fields(&mut variant.fields);
+            }
+        }
+        Data::Union(_) => {}
+    }
+}
+
+fn strip_proto_from_fields(fields: &mut Fields) {
+    match fields {
+        Fields::Named(fields) => {
+            for field in &mut fields.named {
+                strip_proto_from_attrs(&mut field.attrs);
+            }
+        }
+        Fields::Unnamed(fields) => {
+            for field in &mut fields.unnamed {
+                strip_proto_from_attrs(&mut field.attrs);
+            }
+        }
+        Fields::Unit => {}
+    }
+}
+
+fn strip_proto_from_attrs(attrs: &mut Vec<Attribute>) {
+    attrs.retain(|attr| !attr.path().is_ident("proto"));
+}
+
+fn strip_proto_attributes_from_trait(item: &mut ItemTrait) {
+    strip_proto_from_attrs(&mut item.attrs);
+    for trait_item in &mut item.items {
+        match trait_item {
+            syn::TraitItem::Const(const_item) => {
+                strip_proto_from_attrs(&mut const_item.attrs);
+            }
+            syn::TraitItem::Fn(fn_item) => {
+                strip_proto_from_attrs(&mut fn_item.attrs);
+                for input in &mut fn_item.sig.inputs {
+                    if let syn::FnArg::Typed(pat_type) = input {
+                        strip_proto_from_attrs(&mut pat_type.attrs);
+                    }
+                }
+            }
+            syn::TraitItem::Type(type_item) => {
+                strip_proto_from_attrs(&mut type_item.attrs);
+            }
+            syn::TraitItem::Macro(macro_item) => {
+                strip_proto_from_attrs(&mut macro_item.attrs);
+            }
+            syn::TraitItem::Verbatim(_) => {}
+            _ => {}
+        }
+    }
 }

--- a/src/custom_types.rs
+++ b/src/custom_types.rs
@@ -4,6 +4,8 @@
 // #[cfg(feature = "solana")]
 // pub mod solana;
 
+use crate::proto_dump;
+
 #[proto_dump(proto_path = "protos/fastnum.proto")]
 struct D128Proto {
     #[proto(tag = 1)]


### PR DESCRIPTION
## Summary
- filter out `#[proto(...)]` attributes from structs, enums, and traits emitted by the `#[proto_dump]` macro
- import `proto_dump` in `custom_types.rs` so the macro can expand without errors after stripping attributes

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ee23d452b883219cb1617c8b76656f