### PR TITLE
Refine proto traits for zero-copy support

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -163,15 +163,17 @@ impl_google_wrapper!(Bytes, bytes, "BytesValue", |value| value.is_empty(), |valu
 
 /// `google.protobuf.Empty`
 impl ProtoShadow for () {
-    type Sun<'a> = ();
-    type OwnedSun = ();
-    type View<'a> = ();
+    type Sun<'a> = &'a Self;
+    type OwnedSun = Self;
+    type View<'a> = &'a Self;
 
     fn to_sun(self) -> Result<Self::OwnedSun, DecodeError> {
         Ok(())
     }
 
-    fn from_sun<'a>((): Self::Sun<'_>) -> Self::View<'_> {}
+    fn from_sun<'a>(value: Self::Sun<'_>) -> Self::View<'_> {
+        value
+    }
 }
 
 /// `google.protobuf.Empty`


### PR DESCRIPTION
## Summary
- default the tonic ProtoCodec to the borrowed SunByRef mode and clean up the encoder markers
- document the new ProtoShadow/ProtoExt expectations for identity shadows that enable zero-copy paths
- align the unit type's ProtoShadow implementation with the borrowed/&Self defaults

## Testing
- not run (tests require follow-up macro updates)


------
https://chatgpt.com/codex/tasks/task_e_68efd382e34883218b8a8c253fa76fad