### PR TITLE
Refactor derive macros for ProtoShadow integration

### DIFF
--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -31,9 +31,13 @@ pub enum FieldAccess {
 
 impl FieldAccess {
     pub fn self_tokens(&self) -> TokenStream {
+        self.tokens_with_base(quote! { self })
+    }
+
+    pub fn tokens_with_base(&self, base: TokenStream) -> TokenStream {
         match self {
-            FieldAccess::Named(id) => quote! { self.#id },
-            FieldAccess::Tuple(ix) => quote! { self.#ix },
+            FieldAccess::Named(id) => quote! { #base.#id },
+            FieldAccess::Tuple(ix) => quote! { #base.#ix },
         }
     }
 }
@@ -276,7 +280,7 @@ fn decode_scalar(access: &TokenStream, tag: u32, ty: &Type) -> TokenStream {
 
 fn encoded_len_scalar(access: &TokenStream, tag: u32, ty: &Type) -> TokenStream {
     quote! {
-        <#ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &(#access))
+        <#ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &&(#access))
     }
 }
 
@@ -284,7 +288,7 @@ fn encoded_len_scalar_value(value: &TokenStream, tag: u32, ty: &Type) -> TokenSt
     quote! {
         {
             let __value: #ty = #value;
-            <#ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &__value)
+            <#ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &&__value)
         }
     }
 }
@@ -309,7 +313,7 @@ fn decode_message(access: &TokenStream, tag: u32) -> TokenStream {
 }
 
 fn encoded_len_message(access: &TokenStream, tag: u32) -> TokenStream {
-    quote! { ::proto_rs::encoding::message::encoded_len(#tag, &(#access)) }
+    quote! { ::proto_rs::encoding::message::encoded_len(#tag, &&(#access)) }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,15 @@ pub use crate::error::UnknownEnumValue;
 pub use crate::name::Name;
 pub use crate::tonic::ProtoCodec;
 pub use crate::traits::MessageField;
+pub use crate::traits::OwnedSunOf;
 pub use crate::traits::ProtoEnum;
 pub use crate::traits::ProtoExt;
+pub use crate::traits::ProtoShadow;
 pub use crate::traits::RepeatedField;
+pub use crate::traits::Shadow;
 pub use crate::traits::SingularField;
+pub use crate::traits::SunOf;
+pub use crate::traits::ViewOf;
 
 /// Build-time proto schema registry
 /// Only available when "build-schemas" feature is enabled

--- a/src/tonic.rs
+++ b/src/tonic.rs
@@ -12,17 +12,17 @@ use crate::ProtoExt;
 use crate::traits::ProtoShadow;
 
 #[derive(Debug, Clone)]
-pub struct ProtoCodec<Encode = (), Decode = (), Mode = ()> {
+pub struct ProtoCodec<Encode = (), Decode = (), Mode = SunByRef> {
     _marker: PhantomData<(Encode, Decode, Mode)>,
 }
 
-impl<Encode, Decode> Default for ProtoCodec<Encode, Decode> {
+impl<Encode, Decode, Mode> Default for ProtoCodec<Encode, Decode, Mode> {
     fn default() -> Self {
         Self { _marker: PhantomData }
     }
 }
 
-impl<Encode, Decode> ProtoCodec<Encode, Decode> {
+impl<Encode, Decode, Mode> ProtoCodec<Encode, Decode, Mode> {
     pub fn new() -> Self {
         Self { _marker: PhantomData }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,7 +34,6 @@ use crate::encoding::wire_type::WireType;
 use crate::traits::OwnedSunOf;
 use crate::traits::ProtoShadow;
 use crate::traits::Shadow;
-use crate::traits::SunOf;
 use crate::traits::ViewOf;
 
 macro_rules! impl_google_wrapper {


### PR DESCRIPTION
## Summary
- implement ProtoShadow for derive-generated structs and enums and update ProtoExt implementations to use the new view-based signatures
- adjust field handling helpers to pass view references correctly during encoded-length calculation
- re-export trait helpers and update the tonic codec defaults to support reference-based encoding

## Testing
- cargo check -p prosto_derive
- cargo check --example complex


------
https://chatgpt.com/codex/tasks/task_e_68efd76944b483219cfba8f50e4dc6ba