### PR TITLE
Add blanket repeated field support for message types

### DIFF
--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -3,15 +3,20 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
+
 use bytes::Buf;
 use bytes::BufMut;
 
 use crate::DecodeError;
 use crate::MessageField;
 use crate::ProtoExt;
+use crate::RepeatedField;
 use crate::SingularField;
 use crate::encoding::DecodeContext;
 use crate::encoding::wire_type::WireType;
+use crate::traits::OwnedSunOf;
+use crate::traits::ProtoShadow;
 use crate::traits::ViewOf;
 
 // ---------------- Blanket impls for MessageField ----------------
@@ -37,5 +42,40 @@ where
     fn encoded_len_singular_field(tag: u32, value: &ViewOf<'_, Self>) -> usize {
         let len = <Self as ProtoExt>::encoded_len(value);
         if len == 0 { 0 } else { crate::encoding::message::encoded_len::<Self>(tag, value) }
+    }
+}
+
+impl<T> RepeatedField for T
+where
+    T: MessageField,
+    for<'a> <T as ProtoExt>::Shadow<'a>: ProtoShadow<Sun<'a> = &'a T, View<'a> = &'a T, OwnedSun = T>,
+{
+    #[inline]
+    fn encode_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>], buf: &mut impl BufMut) {
+        for value in values {
+            let view = <Self::Shadow<'_> as ProtoShadow>::from_sun(value);
+            crate::encoding::message::encode::<Self>(tag, view, buf);
+        }
+    }
+
+    #[inline]
+    fn merge_repeated_field(
+        wire_type: WireType,
+        values: &mut Vec<Self::Shadow<'_>>,
+        buf: &mut impl Buf,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError> {
+        crate::encoding::message::merge_repeated::<Self>(wire_type, values, buf, ctx)
+    }
+
+    #[inline]
+    fn encoded_len_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>]) -> usize {
+        values
+            .iter()
+            .map(|value| {
+                let view = <Self::Shadow<'_> as ProtoShadow>::from_sun(value);
+                crate::encoding::message::encoded_len::<Self>(tag, &view)
+            })
+            .sum()
     }
 }

--- a/tests/encoding_roundtrip.rs
+++ b/tests/encoding_roundtrip.rs
@@ -460,13 +460,13 @@ fn decode_handles_non_canonical_field_order() {
     encoding::int32::encode(8, &(SampleEnumProst::from(source.mode) as i32), &mut buf);
     encoding::bytes::encode(4, &source.data, &mut buf);
     encoding::int64::encode(7, &source.values[0], &mut buf);
-    encoding::message::encode(6, &source.nested_list[0], &mut buf);
+    encoding::message::encode::<NestedMessage>(6, &source.nested_list[0], &mut buf);
     encoding::string::encode(3, &source.name, &mut buf);
     encoding::bool::encode(2, &source.flag, &mut buf);
     encoding::uint32::encode(1, &source.id, &mut buf);
-    encoding::message::encode(6, &source.nested_list[1], &mut buf);
+    encoding::message::encode::<NestedMessage>(6, &source.nested_list[1], &mut buf);
     encoding::int64::encode(7, &source.values[1], &mut buf);
-    encoding::message::encode(5, source.nested.as_ref().expect("missing nested"), &mut buf);
+    encoding::message::encode::<NestedMessage>(5, source.nested.as_ref().expect("missing nested"), &mut buf);
     encoding::int64::encode(7, &source.values[2], &mut buf);
     encoding::int64::encode(7, &source.values[3], &mut buf);
     if let Some(optional_mode) = source.optional_mode {
@@ -580,7 +580,7 @@ fn enum_discriminants_match_proto_requirements() {
 #[test]
 fn merge_option_box_reuses_allocation() {
     let mut buf = BytesMut::new();
-    encoding::message::encode(1, &NestedMessage { value: 123 }, &mut buf);
+    encoding::message::encode::<NestedMessage>(1, &NestedMessage { value: 123 }, &mut buf);
     let mut bytes = buf.freeze();
 
     let (tag, wire_type) = encoding::decode_key(&mut bytes).expect("decode key");
@@ -600,7 +600,7 @@ fn merge_option_box_reuses_allocation() {
 #[test]
 fn merge_option_arc_reuses_allocation() {
     let mut buf = BytesMut::new();
-    encoding::message::encode(1, &NestedMessage { value: 456 }, &mut buf);
+    encoding::message::encode::<NestedMessage>(1, &NestedMessage { value: 456 }, &mut buf);
     let mut bytes = buf.freeze();
 
     let (tag, wire_type) = encoding::decode_key(&mut bytes).expect("decode key");


### PR DESCRIPTION
## Summary
- add a blanket `RepeatedField` implementation for types that already implement `MessageField`
- remove per-message `RepeatedField` impls from the derive handlers now covered by the blanket

## Testing
- cargo check -p prosto_derive
- cargo check --example prosto_proto

------
https://chatgpt.com/codex/tasks/task_e_68f083b833548321aa3389ace60344af