### PR TITLE
Refine ProtoShadow map handling and update roundtrip tests

### DIFF
--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -13,6 +13,7 @@ use super::unified_field_handler::generate_field_encode;
 use super::unified_field_handler::generate_field_encoded_len;
 use crate::utils::is_option_type;
 use crate::utils::parse_field_config;
+use crate::utils::parse_field_type;
 use crate::utils::vec_inner_type;
 
 pub fn handle_struct(input: DeriveInput, data: &syn::DataStruct) -> TokenStream {
@@ -37,6 +38,11 @@ fn generate_field_clear(field: &syn::Field, access: &FieldAccess) -> TokenStream
     }
 
     if vec_inner_type(field_ty).is_some() {
+        return quote! { #access_tokens.clear(); };
+    }
+
+    let parsed_ty = parse_field_type(field_ty);
+    if parsed_ty.map_kind.is_some() || parsed_ty.set_kind.is_some() {
         return quote! { #access_tokens.clear(); };
     }
 

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -70,6 +70,11 @@ pub fn field_default_expr(field: &Field) -> TokenStream {
         return quote! { Vec::new() };
     }
 
+    let parsed_ty = parse_field_type(field_ty);
+    if parsed_ty.map_kind.is_some() || parsed_ty.set_kind.is_some() {
+        return quote! { ::core::default::Default::default() };
+    }
+
     let cfg = parse_field_config(field);
     if cfg.into_type.is_some() || cfg.from_type.is_some() || cfg.into_fn.is_some() || cfg.from_fn.is_some() || cfg.skip {
         quote! { ::core::default::Default::default() }
@@ -651,9 +656,9 @@ fn encode_map(access: &TokenStream, tag: u32, parsed: &ParsedFieldType, kind: Ma
         if !(#access).is_empty() {
             #module::encode(
                 |tag, key, buf| <#key_ty as ::proto_rs::SingularField>::encode_singular_field(tag, key, buf),
-                |tag, key| <#key_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, key),
+                |tag, key| <#key_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, &key),
                 |tag, value, buf| <#value_ty as ::proto_rs::SingularField>::encode_singular_field(tag, value, buf),
-                |tag, value| <#value_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, value),
+                |tag, value| <#value_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, &value),
                 #tag,
                 &(#access),
                 buf,
@@ -687,8 +692,8 @@ fn encoded_len_map(access: &TokenStream, tag: u32, parsed: &ParsedFieldType, kin
 
     quote! {
         #module::encoded_len(
-            |tag, key| <#key_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, key),
-            |tag, value| <#value_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, value),
+            |tag, key| <#key_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, &key),
+            |tag, value| <#value_ty as ::proto_rs::SingularField>::encoded_len_singular_field(tag, &value),
             #tag,
             &(#access),
         )


### PR DESCRIPTION
## Summary
- ensure derived map and set fields default and clear via standard collection APIs
- fix map encoding/length closures to pass ProtoShadow views into SingularField helpers
- update encoding roundtrip tests to use the new ProtoExt/ProtoShadow interfaces

## Testing
- cargo test --test encoding_roundtrip

------
https://chatgpt.com/codex/tasks/task_e_68f0d7b9dfc48321814317f06d8e5698