### PR TITLE
Fix zero-copy Box/Arc support in proto derive macros

### DIFF
--- a/protos/tests/complex_rpc.proto
+++ b/protos/tests/complex_rpc.proto
@@ -7,4 +7,5 @@ import "encoding.proto";
 service ComplexService {
   rpc EchoSample(encoding.SampleMessage) returns (encoding.SampleMessage) {}
   rpc StreamCollections(encoding.SampleMessage) returns (stream encoding.CollectionsMessage) {}
+  rpc EchoContainer(encoding.ZeroCopyContainer) returns (encoding.ZeroCopyContainer) {}
 }

--- a/protos/tests/encoding.proto
+++ b/protos/tests/encoding.proto
@@ -38,3 +38,12 @@ message SampleMessage {
   optional SampleEnum optional_mode = 9;
 }
 
+message ZeroCopyContainer {
+  bytes bytes32 = 1;
+  repeated uint32 smalls = 2;
+  repeated NestedMessage nested_items = 3;
+  optional NestedMessage boxed = 4;
+  optional NestedMessage shared = 5;
+  map<string, SampleEnum> enum_lookup = 6;
+}
+

--- a/tests/encoding_roundtrip.rs
+++ b/tests/encoding_roundtrip.rs
@@ -27,8 +27,11 @@ pub use encoding_messages::SampleEnumProst;
 pub use encoding_messages::SampleMessage;
 pub use encoding_messages::SampleMessageProst;
 pub use encoding_messages::StatusWithDefaultAttribute;
+pub use encoding_messages::ZeroCopyContainer;
+pub use encoding_messages::ZeroCopyContainerProst;
 pub use encoding_messages::sample_collections_messages as shared_sample_collections_messages;
 pub use encoding_messages::sample_message as shared_sample_message;
+pub use encoding_messages::zero_copy_fixture;
 
 #[proto_message(proto_path = "protos/tests/mixed_roundtrip.proto")]
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -586,6 +589,19 @@ fn enum_discriminants_match_proto_requirements() {
     assert_eq!(SampleEnum::Zero as i32, 0);
     assert_eq!(SampleEnum::One as i32, 1);
     assert_eq!(SampleEnum::Two as i32, 2);
+}
+
+#[test]
+fn zero_copy_container_roundtrip() {
+    let default_container = ZeroCopyContainer::default();
+    assert_eq!(ZeroCopyContainer::encoded_len(&&default_container), 0);
+
+    let fixture = zero_copy_fixture();
+    assert!(ZeroCopyContainer::encoded_len(&&fixture) > 0);
+
+    let encoded = ZeroCopyContainer::encode_to_vec(&fixture);
+    let decoded = ZeroCopyContainer::decode(Bytes::from(encoded)).expect("decode fixture");
+    assert_eq!(decoded, fixture);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- special-case optional Box and Arc fields in the proto_message derive helper to avoid temporary allocations
- extend the encoding proto schema plus RPC proto to include the zero-copy container message
- refresh Rust fixtures, conversions, and integration tests to round-trip the container through tonic/proto RPCs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f0e04c212483219a0406512c908486