### PR TITLE
Optimize repeated message encoding and fix proto wrapper type mapping

### DIFF
--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -159,6 +159,7 @@ fn parse_path_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
             "BTreeMap" => return parse_map_type(path, ty, MapKind::BTreeMap),
             "HashSet" => return parse_set_type(path, ty, SetKind::HashSet),
             "BTreeSet" => return parse_set_type(path, ty, SetKind::BTreeSet),
+            "Box" | "Arc" => return parse_box_like_type(path, ty),
             _ => {}
         }
     }
@@ -202,6 +203,17 @@ fn parse_vec_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
         map_key_type: None,
         map_value_type: None,
     }
+}
+
+fn parse_box_like_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
+    let Some(inner_ty) = single_generic(path) else {
+        panic!("Box-like wrappers must have a single generic argument");
+    };
+
+    let mut inner = parse_field_type(inner_ty);
+    inner.rust_type = ty.clone();
+    inner.elem_type = (*inner_ty).clone();
+    inner
 }
 
 fn parse_primitive_or_custom(ty: &Type) -> ParsedFieldType {

--- a/protos/tests/encoding.proto
+++ b/protos/tests/encoding.proto
@@ -42,8 +42,8 @@ message ZeroCopyContainer {
   bytes bytes32 = 1;
   repeated uint32 smalls = 2;
   repeated NestedMessage nested_items = 3;
-  optional Box boxed = 4;
-  optional Arc shared = 5;
+  optional NestedMessage boxed = 4;
+  optional NestedMessage shared = 5;
   map<string, SampleEnum> enum_lookup = 6;
 }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -800,17 +800,15 @@ pub mod message {
     }
 
     #[inline]
-    pub fn encoded_len_repeated<'a, M, I: ?Sized>(tag: u32, values: &I) -> usize
+    pub fn encoded_len_repeated<'a, M, I>(tag: u32, values: I) -> usize
     where
         M: ProtoExt + 'a,
-        for<'b> &'b I: IntoIterator<Item = ViewOf<'a, M>>,
+        I: IntoIterator<Item = ViewOf<'a, M>>,
     {
-        let mut total = 0;
-        for v in <&I as IntoIterator>::into_iter(values) {
+        values.into_iter().fold(0, |acc, v| {
             let len = M::encoded_len(&v);
-            total += key_len(tag) + encoded_len_varint(len as u64) + len;
-        }
-        total
+            acc + key_len(tag) + encoded_len_varint(len as u64) + len
+        })
     }
     #[inline]
     pub fn encoded_len<M>(tag: u32, msg: &ViewOf<'_, M>) -> usize

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -55,23 +55,18 @@ where
 {
     #[inline]
     fn encode_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>], buf: &mut impl BufMut) {
-        for value in values {
-            let view = <Self::Shadow<'_> as ProtoShadow>::from_sun(value);
-            let len = <Self as ProtoExt>::encoded_len(&view);
-            crate::encoding::encode_key(tag, WireType::LengthDelimited, buf);
-            crate::encoding::encode_varint(len as u64, buf);
-            <Self as ProtoExt>::encode_raw(view, buf);
-        }
+        crate::encoding::message::encode_repeated::<Self, _>(
+            tag,
+            values.iter().map(|value| <Self::Shadow<'_> as ProtoShadow>::from_sun(value)),
+            buf,
+        );
     }
     #[inline]
     fn encoded_len_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>]) -> usize {
-        let mut total = 0usize;
-        for value in values {
-            let view = <Self::Shadow<'_> as ProtoShadow>::from_sun(value);
-            let len = <Self as ProtoExt>::encoded_len(&view);
-            total += crate::encoding::key_len(tag) + crate::encoding::encoded_len_varint(len as u64) + len;
-        }
-        total
+        crate::encoding::message::encoded_len_repeated::<Self, _>(
+            tag,
+            values.iter().map(|value| <Self::Shadow<'_> as ProtoShadow>::from_sun(value)),
+        )
     }
 
     #[inline]


### PR DESCRIPTION
## Summary
- reuse the shared message encoding helpers for repeated message fields to avoid double conversions
- allow the message encoded length helper to consume iterators so the conversion happens once per element
- treat Box/Arc wrappers as transparent when generating .proto files so wrapped messages keep their inner type names

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f105a1b6c08321a650ac34da4bca88