### PR TITLE
Adjust repeated-field encoders to accept iterators

### DIFF
--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -183,11 +183,15 @@ pub fn handle_enum(input: DeriveInput, data: &DataEnum) -> TokenStream {
         }
 
         impl #generics ::proto_rs::RepeatedField for #name #generics {
-            fn encode_repeated_field(
+            fn encode_repeated_field<'a, I>(
                 tag: u32,
-                values: &[::proto_rs::OwnedSunOf<'_, Self>],
+                values: I,
                 buf: &mut impl ::proto_rs::bytes::BufMut,
-            ) {
+            )
+            where
+                Self: 'a,
+                I: ::core::iter::IntoIterator<Item = ::proto_rs::ViewOf<'a, Self>>,
+            {
                 for value in values {
                     let raw = (*value) as i32;
                     ::proto_rs::encoding::int32::encode(tag, &raw, buf);
@@ -224,10 +228,10 @@ pub fn handle_enum(input: DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
-            fn encoded_len_repeated_field(tag: u32, values: &[::proto_rs::OwnedSunOf<'_, Self>]) -> usize {
+            fn encoded_len_repeated_field(tag: u32, values: &[::proto_rs::ViewOf<'_, Self>]) -> usize {
                 let mut total = 0usize;
                 for value in values {
-                    let raw = (*value) as i32;
+                    let raw = (**value) as i32;
                     total += ::proto_rs::encoding::int32::encoded_len(tag, &raw);
                 }
                 total

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -709,7 +709,17 @@ fn encoded_len_array(access: &TokenStream, tag: u32, array: &syn::TypeArray) -> 
 fn encode_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> TokenStream {
     let elem_ty = &parsed.elem_type;
     quote! {
-        <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, &(#access), buf);
+        {
+            let __proto_rs_views: ::proto_rs::alloc::vec::Vec<_> = (#access)
+                .iter()
+                .map(|value| {
+                    <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
+                })
+                .collect();
+            let __proto_rs_len = <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &__proto_rs_views);
+            let _ = __proto_rs_len;
+            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views.into_iter(), buf);
+        }
     }
 }
 
@@ -728,7 +738,17 @@ fn decode_repeated(access: &TokenStream, _tag: u32, parsed: &ParsedFieldType) ->
 fn encoded_len_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> TokenStream {
     let elem_ty = &parsed.elem_type;
     quote! {
-        <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &(#access))
+        if (#access).is_empty() {
+            0
+        } else {
+            let __proto_rs_views: ::proto_rs::alloc::vec::Vec<_> = (#access)
+                .iter()
+                .map(|value| {
+                    <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
+                })
+                .collect();
+            <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &__proto_rs_views)
+        }
     }
 }
 
@@ -794,8 +814,15 @@ fn encode_set(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> Token
     let elem_ty = &parsed.elem_type;
     quote! {
         if !(#access).is_empty() {
-            let __tmp: ::proto_rs::alloc::vec::Vec<#elem_ty> = (#access).iter().cloned().collect();
-            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, &__tmp, buf);
+            let __proto_rs_views: ::proto_rs::alloc::vec::Vec<_> = (#access)
+                .iter()
+                .map(|value| {
+                    <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
+                })
+                .collect();
+            let __proto_rs_len = <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &__proto_rs_views);
+            let _ = __proto_rs_len;
+            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views.into_iter(), buf);
         }
     }
 }
@@ -822,8 +849,13 @@ fn encoded_len_set(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> 
         if (#access).is_empty() {
             0
         } else {
-            let __tmp: ::proto_rs::alloc::vec::Vec<#elem_ty> = (#access).iter().cloned().collect();
-            <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &__tmp)
+            let __proto_rs_views: ::proto_rs::alloc::vec::Vec<_> = (#access)
+                .iter()
+                .map(|value| {
+                    <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
+                })
+                .collect();
+            <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, &__proto_rs_views)
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,8 @@
 use bytes::Buf;
 use bytes::BufMut;
 
+use crate::alloc::vec::Vec;
+
 use crate::DecodeError;
 use crate::EncodeError;
 use crate::encoding::DecodeContext;

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,7 +31,6 @@ use crate::encoding::string;
 use crate::encoding::uint32;
 use crate::encoding::uint64;
 use crate::encoding::wire_type::WireType;
-use crate::traits::OwnedSunOf;
 use crate::traits::ProtoShadow;
 use crate::traits::Shadow;
 use crate::traits::ViewOf;
@@ -105,7 +104,11 @@ macro_rules! impl_google_wrapper {
         }
 
         impl RepeatedField for $ty {
-            fn encode_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>], buf: &mut impl BufMut) {
+            fn encode_repeated_field<'a, I>(tag: u32, values: I, buf: &mut impl BufMut)
+            where
+                Self: 'a,
+                I: IntoIterator<Item = ViewOf<'a, Self>>,
+            {
                 for value in values {
                     $module::encode(tag, value, buf);
                 }
@@ -115,8 +118,8 @@ macro_rules! impl_google_wrapper {
                 $module::merge_repeated(wire_type, values, buf, ctx)
             }
 
-            fn encoded_len_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>]) -> usize {
-                values.iter().map(|value| $module::encoded_len(tag, value)).sum()
+            fn encoded_len_repeated_field(tag: u32, values: &[ViewOf<'_, Self>]) -> usize {
+                values.iter().map(|value| $module::encoded_len(tag, *value)).sum()
             }
         }
 
@@ -317,7 +320,11 @@ macro_rules! impl_narrow_varint {
     };
     (@maybe_repeated true, $ty:ty, $wide_ty:ty, $module:ident, $err:literal) => {
        impl RepeatedField for $ty {
-            fn encode_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>], buf: &mut impl BufMut) {
+            fn encode_repeated_field<'a, I>(tag: u32, values: I, buf: &mut impl BufMut)
+            where
+                Self: 'a,
+                I: IntoIterator<Item = ViewOf<'a, Self>>,
+            {
                 for value in values {
                     let widened: $wide_ty = (*value).into();
                     $module::encode(tag, &widened, buf);
@@ -346,11 +353,11 @@ macro_rules! impl_narrow_varint {
                 }
             }
 
-            fn encoded_len_repeated_field(tag: u32, values: &[OwnedSunOf<'_, Self>]) -> usize {
+            fn encoded_len_repeated_field(tag: u32, values: &[ViewOf<'_, Self>]) -> usize {
                 values
                     .iter()
                     .map(|value| {
-                        let widened: $wide_ty = (*value).into();
+                        let widened: $wide_ty = (**value).into();
                         $module::encoded_len(tag, &widened)
                     })
                     .sum()

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -18,7 +18,6 @@ use crate::RepeatedField;
 use crate::SingularField;
 use crate::encoding::DecodeContext;
 use crate::encoding::wire_type::WireType;
-use crate::traits::OwnedSunOf;
 use crate::traits::ProtoShadow;
 use crate::traits::ViewOf;
 
@@ -56,8 +55,8 @@ where
     #[inline]
     fn encode_repeated_field<'a, I>(tag: u32, values: I, buf: &mut impl BufMut)
     where
-        T: ProtoExt + 'a,
-        I: IntoIterator<Item = ViewOf<'a, T>>,
+        Self: 'a,
+        I: IntoIterator<Item = ViewOf<'a, Self>>,
     {
         crate::encoding::message::encode_repeated::<Self, _>(tag, values, buf);
     }


### PR DESCRIPTION
## Summary
- allow `RepeatedField::encode_repeated_field` and the message encoding helper to take any iterator of precomputed views
- update wrapper, scalar, and enum repeated-field implementations to forward iterators and avoid unnecessary allocations
- adjust the derive helpers to pass `into_iter()` so collected view vectors are consumed by the new APIs

## Testing
- cargo test --test encoding_roundtrip

------
https://chatgpt.com/codex/tasks/task_e_68f133012ce483219d67d092db860490