### PR TITLE
Refactor Solana ProtoExt to use shadow trait

### DIFF
--- a/src/custom_types/solana/address.rs
+++ b/src/custom_types/solana/address.rs
@@ -45,7 +45,11 @@ mod tests {
         encode_varint((BYTES - 1) as u64, &mut buf);
         buf.extend(std::iter::repeat(0u8).take(BYTES - 1));
 
-        let err = <ByteSeq as ProtoExt>::decode(buf.as_slice()).expect_err("invalid length should fail");
-        assert!(err.to_string().contains("expected"));
+        match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
+            Ok(_) => panic!("invalid length should fail"),
+            Err(err) => {
+                assert!(err.to_string().contains("invalid length for Solana byte array"));
+            }
+        }
     }
 }

--- a/src/custom_types/solana/common.rs
+++ b/src/custom_types/solana/common.rs
@@ -1,55 +1,76 @@
 #[macro_export]
 macro_rules! impl_protoext_for_byte_array {
-    ($ty:ident, $bytes:ident) => {
+    ($ty:ty, $bytes:expr) => {
+        impl $crate::traits::ProtoShadow for $ty {
+            type Sun<'a> = &'a Self;
+            type OwnedSun = Self;
+            type View<'a> = &'a Self;
+
+            #[inline]
+            fn to_sun(self) -> Result<Self::OwnedSun, $crate::DecodeError> {
+                Ok(self)
+            }
+
+            #[inline]
+            fn from_sun(value: Self::Sun<'_>) -> Self::View<'_> {
+                value
+            }
+        }
+
         impl $crate::ProtoExt for $ty {
-            fn proto_default() -> Self
-            where
-                Self: Sized,
-            {
+            type Shadow<'a> = Self;
+
+            #[inline]
+            fn proto_default<'a>() -> Self::Shadow<'a> {
                 Self::default()
             }
 
-            fn encode_raw(&self, buf: &mut impl bytes::BufMut)
-            where
-                Self: Sized,
-            {
-                $crate::encoding::encode_key(1, $crate::encoding::WireType::LengthDelimited, buf);
-                $crate::encoding::encode_varint($bytes as u64, buf);
-                buf.put_slice(self.as_ref());
+            #[inline]
+            fn encoded_len(_value: &$crate::traits::ViewOf<'_, Self>) -> usize {
+                const TAG_LEN: usize = 1;
+                TAG_LEN + $crate::encoding::encoded_len_varint($bytes as u64) + $bytes
             }
 
-            fn merge_field(&mut self, tag: u32, wire_type: $crate::encoding::WireType, buf: &mut impl bytes::Buf, ctx: $crate::encoding::DecodeContext) -> Result<(), $crate::DecodeError>
-            where
-                Self: Sized,
-            {
+            #[inline]
+            fn encode_raw(value: $crate::traits::ViewOf<'_, Self>, buf: &mut impl ::bytes::BufMut) {
+                debug_assert_eq!(value.as_ref().len(), $bytes);
+                $crate::encoding::encode_key(1, $crate::encoding::WireType::LengthDelimited, buf);
+                $crate::encoding::encode_varint($bytes as u64, buf);
+                buf.put_slice(value.as_ref());
+            }
+
+            #[inline]
+            fn merge_field(
+                value: &mut Self::Shadow<'_>,
+                tag: u32,
+                wire_type: $crate::encoding::WireType,
+                buf: &mut impl ::bytes::Buf,
+                ctx: $crate::encoding::DecodeContext,
+            ) -> Result<(), $crate::DecodeError> {
                 if tag == 1 {
                     if wire_type != $crate::encoding::WireType::LengthDelimited {
-                        return Err($crate::DecodeError::new("invalid wire type"));
+                        return Err($crate::DecodeError::new("invalid wire type for Solana byte array"));
                     }
 
-                    let len = $crate::encoding::decode_varint(buf)?;
-                    if buf.remaining() < len as usize {
+                    let len = $crate::encoding::decode_varint(buf)? as usize;
+                    if len != $bytes {
+                        return Err($crate::DecodeError::new("invalid length for Solana byte array"));
+                    }
+
+                    if buf.remaining() < $bytes {
                         return Err($crate::DecodeError::new("buffer underflow"));
                     }
-                    if len as usize != $bytes {
-                        return Err($crate::DecodeError::new(format!("expected {} bytes, got {}", $bytes, len)));
-                    }
+
                     let mut data = [0u8; $bytes];
                     buf.copy_to_slice(&mut data);
-                    *self = <$ty as From<[u8; $bytes]>>::from(data);
+                    *value = <$ty as From<[u8; $bytes]>>::from(data);
                     Ok(())
                 } else {
                     $crate::encoding::skip_field(wire_type, tag, buf, ctx)
                 }
             }
 
-            fn encoded_len(&self) -> usize {
-                let tag_len = 1;
-                let len_varint_len = $crate::encoding::encoded_len_varint($bytes as u64);
-                let data_len = $bytes;
-                tag_len + len_varint_len + data_len
-            }
-
+            #[inline]
             fn clear(&mut self) {
                 *self = Self::default();
             }

--- a/src/custom_types/solana/signature.rs
+++ b/src/custom_types/solana/signature.rs
@@ -17,8 +17,8 @@ impl_protoext_for_byte_array!(ByteSeq, BYTES);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encoding::{encode_key, encode_varint, WireType};
     use crate::ProtoExt;
+    use crate::encoding::{WireType, encode_key, encode_varint};
 
     fn sample_signature_bytes() -> [u8; BYTES] {
         let mut data = [0u8; BYTES];
@@ -43,7 +43,11 @@ mod tests {
         encode_varint((BYTES - 2) as u64, &mut buf);
         buf.extend(std::iter::repeat(0u8).take(BYTES - 2));
 
-        let err = <ByteSeq as ProtoExt>::decode(buf.as_slice()).expect_err("invalid length should fail");
-        assert!(err.to_string().contains("expected"));
+        match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
+            Ok(_) => panic!("invalid length should fail"),
+            Err(err) => {
+                assert!(err.to_string().contains("invalid length for Solana byte array"));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement the ProtoShadow trait for Solana address and signature types through the shared byte-array macro
- refactor the byte-array ProtoExt macro to the new zero-copy friendly design with static error messages
- update Solana tests to avoid Debug bounds and validate the new error wording

## Testing
- cargo test --features solana --lib custom_types::solana::address::tests::roundtrip_proto_ext -- --nocapture
- cargo test --features solana --lib custom_types::solana::signature::tests::roundtrip_proto_ext -- --nocapture
- cargo test --features solana --lib custom_types::solana::address::tests::rejects_incorrect_length -- --nocapture
- cargo test --features solana --lib custom_types::solana::signature::tests::rejects_incorrect_length -- --nocapture
- cargo check --features solana

------
https://chatgpt.com/codex/tasks/task_e_68f244872fc483218fad039efe60fc7d