### PR TITLE
Refine fastnum sun conversions

### DIFF
--- a/src/custom_types/fastnum/signed.rs
+++ b/src/custom_types/fastnum/signed.rs
@@ -1,12 +1,13 @@
+use core::convert::TryInto;
+
 use fastnum::D128;
 
-use crate::ProtoExt;
-use crate::proto_dump;
-extern crate self as proto_rs;
+use crate::DecodeError;
+use crate::ProtoShadow;
+use crate::proto_message;
 
-//DO NOT USE IT FOR ENCODE\DECODE
-#[proto_dump(proto_path = "protos/fastnum.proto")]
-struct D128Proto {
+#[proto_message(proto_path = "protos/fastnum.proto", sun = D128)]
+pub struct D128Proto {
     #[proto(tag = 1)]
     /// Lower 64 bits of the digits
     pub lo: u64,
@@ -21,38 +22,83 @@ struct D128Proto {
     pub is_negative: bool,
 }
 
+impl ProtoShadow for D128Proto {
+    type Sun<'a> = &'a D128;
+    type OwnedSun = D128;
+    type View<'a> = Self;
+
+    fn to_sun(self) -> Result<Self::OwnedSun, DecodeError> {
+        let digits = ((self.hi as u128) << 64) | (self.lo as u128);
+
+        let mut result = D128::from_u128(digits).map_err(|err| DecodeError::new(err.to_string()))?;
+
+        if self.fractional_digits_count > 0 {
+            result /= D128::TEN.powi(self.fractional_digits_count);
+        } else if self.fractional_digits_count < 0 {
+            result *= D128::TEN.powi(-self.fractional_digits_count);
+        }
+
+        if self.is_negative {
+            result = -result;
+        }
+
+        Ok(result)
+    }
+
+    fn from_sun(value: Self::Sun<'_>) -> Self::View<'_> {
+        let digits: u128 = value.digits().try_into().expect("Should be safe as D128 should have u128 capacity");
+        let lo = digits as u64;
+        let hi = (digits >> 64) as u64;
+
+        Self {
+            lo,
+            hi,
+            fractional_digits_count: i32::from(value.fractional_digits_count()),
+            is_negative: value.is_sign_negative(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use fastnum::dec128;
 
     use super::*;
 
+    fn encode(value: &D128) -> D128Proto {
+        <D128Proto as ProtoShadow>::from_sun(value)
+    }
+
+    fn decode(proto: D128Proto) -> D128 {
+        ProtoShadow::to_sun(proto).unwrap()
+    }
+
     #[test]
     fn test_roundtrip() {
         let original = dec128!(123456789.987654321);
-        let proto = original.to_proto();
-        let restored = D128::from_proto(proto).unwrap();
+        let proto = encode(&original);
+        let restored = decode(proto);
         assert_eq!(original, restored);
     }
 
     #[test]
     fn test_negative_value() {
         let val = dec128!(-123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert!(proto.is_negative);
         assert_eq!(proto.fractional_digits_count, 2);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_positive_value() {
         let val = dec128!(123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert!(!proto.is_negative);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
@@ -60,10 +106,10 @@ mod tests {
     fn test_fractional_digits() {
         // Test case from docs: 123.45 has 2 fractional digits
         let val = dec128!(123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 2);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
@@ -71,28 +117,28 @@ mod tests {
     fn test_scientific_notation() {
         // Test case: 5e9 has -9 fractional digits
         let val = dec128!(5e9);
-        let proto = val.to_proto();
-        let restored = D128::from_proto(proto).unwrap();
+        let proto = encode(&val);
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_negative_scientific() {
         let val = dec128!(-5e9);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert!(proto.is_negative);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_no_fractional_part() {
         let val = dec128!(12345);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 0);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
@@ -100,47 +146,47 @@ mod tests {
     fn test_small_fractional() {
         // Test case: 0.0000012345 has 10 fractional digits
         let val = dec128!(0.0000012345);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 10);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_max_value() {
         let max_val = D128::MAX;
-        let proto = max_val.to_proto();
-        let restored = D128::from_proto(proto).unwrap();
+        let proto = encode(&max_val);
+        let restored = decode(proto);
         assert_eq!(max_val, restored);
     }
 
     #[test]
     fn test_min_value() {
         let min_val = D128::MIN;
-        let proto = min_val.to_proto();
+        let proto = encode(&min_val);
         assert!(proto.is_negative);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(min_val, restored);
     }
 
     #[test]
     fn test_zero() {
         let zero = D128::ZERO;
-        let proto = zero.to_proto();
+        let proto = encode(&zero);
         assert!(!proto.is_negative);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(zero, restored);
     }
 
     #[test]
     fn test_negative_zero() {
         let neg_zero = dec128!(-0.0);
-        let proto = neg_zero.to_proto();
+        let proto = encode(&neg_zero);
 
-        let restored = D128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(neg_zero, restored);
     }
 
@@ -148,7 +194,7 @@ mod tests {
     fn test_proto_fields() {
         // Verify proto structure for -123.45
         let val = dec128!(-123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
 
         // digits = 12345 (absolute value), fractional_count = 2, negative = true
         let digits = ((proto.hi as u128) << 64) | (proto.lo as u128);

--- a/src/custom_types/fastnum/unsigned.rs
+++ b/src/custom_types/fastnum/unsigned.rs
@@ -1,21 +1,55 @@
+use core::convert::TryInto;
+
 use fastnum::UD128;
 
-use crate::proto_dump;
-extern crate self as proto_rs;
+use crate::DecodeError;
+use crate::ProtoShadow;
+use crate::proto_message;
 
-//DO NOT USE IT FOR ENCODE\DECODE
-#[proto_dump(proto_path = "protos/fastnum.proto")]
-#[derive(prost::Message, Clone, PartialEq, Copy)]
+#[proto_message(proto_path = "protos/fastnum.proto", sun = UD128)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct UD128Proto {
-    #[prost(uint64, tag = 1)]
+    #[proto(tag = 1)]
     /// Lower 64 bits of the digits
     pub lo: u64,
-    #[prost(uint64, tag = 2)]
+    #[proto(tag = 2)]
     /// Upper 64 bits of the digits
     pub hi: u64,
-    #[prost(int32, tag = 3)]
+    #[proto(tag = 3)]
     /// Fractional digits count (can be negative for scientific notation)
     pub fractional_digits_count: i32,
+}
+
+impl ProtoShadow for UD128Proto {
+    type Sun<'a> = &'a UD128;
+    type OwnedSun = UD128;
+    type View<'a> = Self;
+
+    fn to_sun(self) -> Result<Self::OwnedSun, DecodeError> {
+        let digits = ((self.hi as u128) << 64) | (self.lo as u128);
+
+        let mut result = UD128::from_u128(digits).map_err(|err| DecodeError::new(err.to_string()))?;
+
+        if self.fractional_digits_count > 0 {
+            result /= UD128::TEN.powi(self.fractional_digits_count);
+        } else if self.fractional_digits_count < 0 {
+            result *= UD128::TEN.powi(-self.fractional_digits_count);
+        }
+
+        Ok(result)
+    }
+
+    fn from_sun(value: Self::Sun<'_>) -> Self::View<'_> {
+        let digits: u128 = value.digits().try_into().expect("Should be safe as UD128 should have u128 capacity");
+        let lo = digits as u64;
+        let hi = (digits >> 64) as u64;
+
+        Self {
+            lo,
+            hi,
+            fractional_digits_count: i32::from(value.fractional_digits_count()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -25,11 +59,19 @@ mod tests {
 
     use super::*;
 
+    fn encode(value: &UD128) -> UD128Proto {
+        <UD128Proto as ProtoShadow>::from_sun(value)
+    }
+
+    fn decode(proto: UD128Proto) -> UD128 {
+        ProtoShadow::to_sun(proto).unwrap()
+    }
+
     #[test]
     fn test_roundtrip() {
         let original = udec128!(123456789.987654321);
-        let proto = original.to_proto();
-        let restored = UD128::from_proto(proto).unwrap();
+        let proto = encode(&original);
+        let restored = decode(proto);
         assert_eq!(original, restored);
     }
 
@@ -37,10 +79,10 @@ mod tests {
     fn test_fractional_digits() {
         // Test case from docs: 123.45 has 2 fractional digits
         let val = udec128!(123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 2);
 
-        let restored = UD128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
@@ -48,18 +90,18 @@ mod tests {
     fn test_scientific_notation() {
         // Test case: 5e9 has -9 fractional digits
         let val = udec128!(5e9);
-        let proto = val.to_proto();
-        let restored = UD128::from_proto(proto).unwrap();
+        let proto = encode(&val);
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_no_fractional_part() {
         let val = udec128!(12345);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 0);
 
-        let restored = UD128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
@@ -67,26 +109,26 @@ mod tests {
     fn test_small_fractional() {
         // Test case: 0.0000012345 has 10 fractional digits
         let val = udec128!(0.0000012345);
-        let proto = val.to_proto();
+        let proto = encode(&val);
         assert_eq!(proto.fractional_digits_count, 10);
 
-        let restored = UD128::from_proto(proto).unwrap();
+        let restored = decode(proto);
         assert_eq!(val, restored);
     }
 
     #[test]
     fn test_max_value() {
         let max_val = UD128::MAX;
-        let proto = max_val.to_proto();
-        let restored = UD128::from_proto(proto).unwrap();
+        let proto = encode(&max_val);
+        let restored = decode(proto);
         assert_eq!(max_val, restored);
     }
 
     #[test]
     fn test_zero() {
         let zero = UD128::ZERO;
-        let proto = zero.to_proto();
-        let restored = UD128::from_proto(proto).unwrap();
+        let proto = encode(&zero);
+        let restored = decode(proto);
         assert_eq!(zero, restored);
     }
 
@@ -94,7 +136,7 @@ mod tests {
     fn test_proto_fields() {
         // Verify proto structure for 123.45
         let val = udec128!(123.45);
-        let proto = val.to_proto();
+        let proto = encode(&val);
 
         // digits = 12345, fractional_count = 2
         // Reconstruct: (hi << 64) | lo = digits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::cast_lossless)]
 
+extern crate self as proto_rs;
+
 pub use prosto_derive::inject_proto_import;
 pub use prosto_derive::proto_dump;
 pub use prosto_derive::proto_message;


### PR DESCRIPTION
## Summary
- drop the FastnumProtoExt helper trait so fastnum types rely directly on ProtoShadow
- implement u128-based conversions for D128/UD128 sun mode, including sign and scale handling
- update fastnum tests to encode/decode via ProtoShadow helpers

## Testing
- cargo test --features fastnum --lib custom_types::fastnum::signed::tests::test_roundtrip
- cargo test --features fastnum --lib custom_types::fastnum::unsigned::tests::test_roundtrip

------
https://chatgpt.com/codex/tasks/task_e_68f2548062588321a376b4fcc5022d7f