### PR TITLE
Rewrite RPC service trait methods to use RPIT futures

### DIFF
--- a/crates/prosto_derive/src/proto_rpc/utils.rs
+++ b/crates/prosto_derive/src/proto_rpc/utils.rs
@@ -85,32 +85,26 @@ fn generate_user_method_signature(
         let stream_name = stream_type_name.unwrap();
         quote! {
             #(#attrs)*
-            fn #method_name<'life0, 'async_trait>(
-                &'life0 self,
+            fn #method_name(
+                &self,
                 request: tonic::Request<#request_type>,
-            ) -> ::core::pin::Pin<Box<
-                dyn ::core::future::Future<
-                    Output = Result<tonic::Response<Self::#stream_name>, tonic::Status>
-                > + ::core::marker::Send + 'async_trait
-            >>
+            ) -> impl std::future::Future<
+                Output = std::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
+            > + ::core::marker::Send
             where
-                'life0: 'async_trait,
-                Self: 'async_trait;
+                Self: std::marker::Send + std::marker::Sync;
         }
     } else {
         quote! {
             #(#attrs)*
-            fn #method_name<'life0, 'async_trait>(
-                &'life0 self,
+            fn #method_name(
+                &self,
                 request: tonic::Request<#request_type>,
-            ) -> ::core::pin::Pin<Box<
-                dyn ::core::future::Future<
-                    Output = Result<tonic::Response<#response_type>, tonic::Status>
-                > + ::core::marker::Send + 'async_trait
-            >>
+            ) -> impl std::future::Future<
+                Output = std::result::Result<tonic::Response<#response_type>, tonic::Status>
+            > + ::core::marker::Send
             where
-                'life0: 'async_trait,
-                Self: 'async_trait;
+                Self: std::marker::Send + std::marker::Sync;
         }
     }
 }

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -75,7 +75,6 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tonic::async_trait]
 impl SigmaRpc for S {
     type RizzUniStream = Pin<Box<dyn Stream<Item = Result<FooResponse, Status>> + Send>>;
     async fn rizz_ping(&self, _req: Request<RizzPing>) -> Result<Response<GoonPong>, Status> {

--- a/examples/proto_gen_example.rs
+++ b/examples/proto_gen_example.rs
@@ -54,7 +54,6 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tonic::async_trait]
 impl SigmaRpc for S {
     type RizzUniStream = Pin<Box<dyn Stream<Item = Result<FooResponse, Status>> + Send>>;
     async fn rizz_ping(&self, _req: Request<RizzPing>) -> Result<Response<GoonPong>, Status> {

--- a/tests/proto_rs_test/src/main.rs
+++ b/tests/proto_rs_test/src/main.rs
@@ -15,7 +15,6 @@ use tonic::Status;
 // A dummy server impl
 struct S;
 
-#[tonic::async_trait]
 impl SigmaRpc for S {
     type RizzUniStream = Pin<Box<dyn Stream<Item = Result<FooResponse, Status>> + Send>>;
     async fn rizz_ping(&self, _req: Request<RizzPing>) -> Result<Response<GoonPong>, Status> {

--- a/tests/rpc_integration.rs
+++ b/tests/rpc_integration.rs
@@ -203,7 +203,6 @@ fn container_from_tonic(msg: tonic_prost_test::encoding::ZeroCopyContainer) -> Z
 
 struct OurService;
 
-#[tonic::async_trait]
 impl ComplexService for OurService {
     type StreamCollectionsStream = Pin<Box<dyn Stream<Item = Result<CollectionsMessage, Status>> + Send>>;
 


### PR DESCRIPTION
## Summary
- update generated RPC service traits to return RPIT futures instead of boxed trait objects
- adjust blanket implementations to emit async blocks directly matching the new signatures

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f3b9c777b48321ac5bd39690170df6