### PR TITLE
Refactor generated server futures to use impl Future

### DIFF
--- a/crates/prosto_derive/src/proto_rpc/server.rs
+++ b/crates/prosto_derive/src/proto_rpc/server.rs
@@ -327,14 +327,15 @@ fn generate_unary_route_handler(method: &MethodInfo, route_path: &str, svc_name:
 
             impl<T: #trait_name> tonic::server::UnaryService<#request_proto> for #svc_name<T> {
                 type Response = #response_proto;
-                type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                type Future = impl std::future::Future<
+                        Output = std::result::Result<tonic::Response<Self::Response>, tonic::Status>
+                    > + std::marker::Send + 'static;
 
                 fn call(&mut self, request: tonic::Request<#request_proto>) -> Self::Future {
                     let inner = Arc::clone(&self.0);
-                    let fut = async move {
+                    async move {
                         <T as #trait_name>::#method_name(&inner, request).await
-                    };
-                    Box::pin(fut)
+                    }
                 }
             }
 
@@ -384,14 +385,15 @@ fn generate_streaming_route_handler(method: &MethodInfo, route_path: &str, svc_n
             impl<T: #trait_name> tonic::server::ServerStreamingService<#request_proto> for #svc_name<T> {
                 type Response = #response_proto;
                 type ResponseStream = T::#stream_name;
-                type Future = BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                type Future = impl std::future::Future<
+                        Output = std::result::Result<tonic::Response<Self::ResponseStream>, tonic::Status>
+                    > + std::marker::Send + 'static;
 
                 fn call(&mut self, request: tonic::Request<#request_proto>) -> Self::Future {
                     let inner = Arc::clone(&self.0);
-                    let fut = async move {
+                    async move {
                         <T as #trait_name>::#method_name(&inner, request).await
-                    };
-                    Box::pin(fut)
+                    }
                 }
             }
 

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -1,3 +1,5 @@
+#![feature(impl_trait_in_assoc_type)]
+#![allow(incomplete_features)]
 #![allow(clippy::missing_errors_doc)]
 use std::pin::Pin;
 

--- a/examples/proto_gen_example.rs
+++ b/examples/proto_gen_example.rs
@@ -1,3 +1,5 @@
+#![feature(impl_trait_in_assoc_type)]
+#![allow(incomplete_features)]
 #![allow(clippy::missing_errors_doc)]
 
 use std::pin::Pin;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(impl_trait_in_assoc_type)]
+#![allow(incomplete_features)]
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::cast_possible_truncation)]

--- a/tests/proto_build_test/src/main.rs
+++ b/tests/proto_build_test/src/main.rs
@@ -1,3 +1,6 @@
+#![feature(impl_trait_in_assoc_type)]
+#![allow(incomplete_features)]
+
 use proto_rs::proto_message;
 use proto_rs::proto_rpc;
 use tokio_stream::Stream;

--- a/tests/rpc_integration.rs
+++ b/tests/rpc_integration.rs
@@ -1,3 +1,6 @@
+#![feature(impl_trait_in_assoc_type)]
+#![allow(incomplete_features)]
+
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary
- replace the boxed futures in generated server RPC service implementations with RPITIT-based `impl Future` return types
- require the nightly toolchain and enable the `impl_trait_in_assoc_type` feature in the library, examples, and integration tests to compile the new futures

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f3ca8bd4688321860fe45888cd7d4c