### PR TITLE
Support broad ProtoResponse types for unary RPCs

### DIFF
--- a/crates/prosto_derive/src/proto_rpc/rpc_common.rs
+++ b/crates/prosto_derive/src/proto_rpc/rpc_common.rs
@@ -33,11 +33,6 @@ pub fn generate_proto_to_native_response(_response_type: &Type) -> TokenStream {
     quote! { Ok(response) }
 }
 
-/// Generate native-to-proto response conversion (used in server)
-pub fn generate_native_to_proto_response() -> TokenStream {
-    quote! { Ok(native_response) }
-}
-
 // ============================================================================
 // PROTO TYPE HELPERS
 // ============================================================================

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -153,6 +153,8 @@ pub struct MethodInfo {
     pub name: syn::Ident,
     pub request_type: Box<Type>,
     pub response_type: Box<Type>,
+    pub response_return_type: Box<Type>,
+    pub response_is_result: bool,
     pub is_streaming: bool,
     pub stream_type_name: Option<syn::Ident>,
     pub inner_response_type: Option<Type>,

--- a/examples/proto_gen_example.rs
+++ b/examples/proto_gen_example.rs
@@ -3,7 +3,6 @@
 
 use std::pin::Pin;
 
-use proto_rs::ProtoResponse;
 use proto_rs::ToZeroCopyResponse;
 use proto_rs::ZeroCopyResponse;
 use proto_rs::proto_message;
@@ -35,7 +34,7 @@ pub struct BarSub;
 #[proto_imports(rizz_types = ["BarSub", "FooResponse"], goon_types = ["RizzPing", "GoonPong"] )]
 pub trait SigmaRpc {
     async fn zero_copy_ping(&self, request: Request<RizzPing>) -> Result<ZeroCopyResponse<GoonPong>, Status>;
-    async fn just_ping(&self, request: Request<RizzPing>) -> Result<GoonPong>, Status>;
+    async fn just_ping(&self, request: Request<RizzPing>) -> Result<GoonPong, Status>;
     async fn infallible_just_ping(&self, request: Request<RizzPing>) -> GoonPong;
     async fn infallible_zero_copy_ping(&self, request: Request<RizzPing>) -> ZeroCopyResponse<GoonPong>;
     async fn infallible_ping(&self, request: Request<RizzPing>) -> Response<GoonPong>;
@@ -63,11 +62,28 @@ pub async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 impl SigmaRpc for S {
-    type ZeroCopyPingResp = ZeroCopyResponse<GoonPong>;
     type RizzUniStream = Pin<Box<dyn Stream<Item = Result<FooResponse, Status>> + Send>>;
-    async fn zero_copy_ping(&self, _request: Request<RizzPing>) -> Result<Self::ZeroCopyPingResp, Status> {
+
+    async fn zero_copy_ping(&self, _request: Request<RizzPing>) -> Result<ZeroCopyResponse<GoonPong>, Status> {
         Ok(GoonPong {}.to_zero_copy())
     }
+
+    async fn just_ping(&self, _request: Request<RizzPing>) -> Result<GoonPong, Status> {
+        Ok(GoonPong {})
+    }
+
+    async fn infallible_just_ping(&self, _request: Request<RizzPing>) -> GoonPong {
+        GoonPong {}
+    }
+
+    async fn infallible_zero_copy_ping(&self, _request: Request<RizzPing>) -> ZeroCopyResponse<GoonPong> {
+        GoonPong {}.to_zero_copy()
+    }
+
+    async fn infallible_ping(&self, _request: Request<RizzPing>) -> Response<GoonPong> {
+        Response::new(GoonPong {})
+    }
+
     async fn rizz_ping(&self, _req: Request<RizzPing>) -> Result<Response<GoonPong>, Status> {
         Ok(Response::new(GoonPong {}))
     }


### PR DESCRIPTION
## Summary
- teach the macro utilities to capture each unary method's declared response type and whether it returns a `Result`
- update the generated server trait, blanket impl, and route handler to coerce any `ProtoResponse` implementor and configure codecs with the correct encode/mode types
- refresh the example service implementation to use the broader response forms directly

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f4d2b38140832193f746de6adeefe5