### PR TITLE
Refactor macros for lean core support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,13 @@ resolver = "3"
 prosto_derive = { version = "0.6", path = "crates/prosto_derive" }
 proto_rs = { version = "0.6", path = "./" }
 prost = "0.14.1"
-bytes = "1.10"
+bytes = { version = "1.10", default-features = false }
 
 
 [dependencies]
 prosto_derive.workspace = true
 bytes.workspace = true
-tonic = "0.14.2"
+tonic = { version = "0.14.2", optional = true }
 fastnum = { version = "0.7.2", optional = true }
 inventory = { version = "0.3.21", optional = true }
 solana-address = { version = "1", optional = true }
@@ -72,7 +72,7 @@ tonic_prost_test = { path = "tests/tonic_prost_test" }
 
 
 [features]
-std = []
+std = ["dep:tonic", "bytes/std"]
 fastnum = ["dep:fastnum"]
 solana = ["dep:solana-address", "dep:solana-signature"]
 # Schema collection for build scripts

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For fellow proto <-> native typeconversions enjoyers <=0.5.0 versions of this cr
 - **On-demand schema dumps** – `#[proto_dump]` and `inject_proto_import!` let you register standalone definitions or imports when you need to compose more complex schemas.
 - **Workspace and even beyond schema registry** – With the `build-schemas` feature enabled you can aggregate every proto that was emitted by your dependency tree and write it to disk via [`proto_rs::schemas::write_all`](src/lib.rs).
 - **Opt-in `.proto` emission** – Proto files are written only when you ask for them via the `emit-proto-files` cargo feature or the `PROTO_EMIT_FILE=1` environment variable, making it easy to toggle between codegen and incremental development.
+- **`no_std` friendly core** – Runtime helpers rely on `core`/`alloc` so they keep working even when the `std` feature is disabled.
 
 ## Getting started
 
@@ -61,6 +62,17 @@ pub trait SigmaRpc {
 
 Once compiled, the trait can be implemented just like a normal Tonic service, but the `.proto` schema is generated for you whenever emission is enabled.
 
+### Running without `std`
+
+Disable the default feature set if you only need message encoding/decoding in `no_std` contexts:
+
+```toml
+[dependencies]
+proto_rs = { version = "0.6", default-features = false }
+```
+
+All core traits (`ProtoExt`, `MessageField`, wrappers, etc.) remain available. Re-enable the `std` feature (on by default) when you want the Tonic codec helpers and RPC generation macros.
+
 ## Collecting schemas across a workspace
 
 Enable the `build-schemas` feature for the crate that should aggregate `.proto` files and call the helper at build or runtime:
@@ -103,9 +115,9 @@ The test suite exercises more than 400 codec and integration scenarios to ensure
 
 ## Optional features
 
+- `std` *(default)* – pulls in the Tonic dependency tree and enables the RPC helpers.
 - `build-schemas` – register generated schemas at compile time so they can be written later.
 - `emit-proto-files` – eagerly write `.proto` files during compilation.
-- `fastnum`, `solana` – enable extra type support
+- `fastnum`, `solana` – enable extra type support.
 
-TODO! (no good docs yet)
 For the full API surface and macro documentation see [docs.rs/proto_rs](https://docs.rs/proto_rs).

--- a/crates/prosto_derive/src/lib.rs
+++ b/crates/prosto_derive/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::similar_names)]
+extern crate alloc;
 use proc_macro::TokenStream;
 
 mod emit_proto;

--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -200,7 +200,7 @@ pub fn handle_enum(input: DeriveInput, data: &DataEnum) -> TokenStream {
 
             fn merge_repeated_field(
                 wire_type: ::proto_rs::encoding::WireType,
-                values: &mut ::std::vec::Vec<Self::Shadow<'_>>,
+                values: &mut ::proto_rs::alloc::vec::Vec<Self::Shadow<'_>>,
                 buf: &mut impl ::proto_rs::bytes::Buf,
                 ctx: ::proto_rs::encoding::DecodeContext,
             ) -> Result<(), ::proto_rs::DecodeError> {

--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -1096,15 +1096,15 @@ fn decode_option_box(access: &TokenStream, _tag: u32, inner_ty: &Type) -> TokenS
                 ctx.clone(),
             )?;
         } else {
-            let mut __proto_rs_tmp: <::std::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::Shadow<'_> =
-                <::std::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::proto_default();
-            <::std::boxed::Box<#inner_ty> as ::proto_rs::SingularField>::merge_singular_field(
+            let mut __proto_rs_tmp: <::proto_rs::alloc::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::Shadow<'_> =
+                <::proto_rs::alloc::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::proto_default();
+            <::proto_rs::alloc::boxed::Box<#inner_ty> as ::proto_rs::SingularField>::merge_singular_field(
                 wire_type,
                 &mut __proto_rs_tmp,
                 buf,
                 ctx.clone(),
             )?;
-            let __proto_rs_owned = <::std::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::post_decode(__proto_rs_tmp)?;
+            let __proto_rs_owned = <::proto_rs::alloc::boxed::Box<#inner_ty> as ::proto_rs::ProtoExt>::post_decode(__proto_rs_tmp)?;
             (#access) = Some(__proto_rs_owned);
         }
     }
@@ -1112,21 +1112,21 @@ fn decode_option_box(access: &TokenStream, _tag: u32, inner_ty: &Type) -> TokenS
 
 fn decode_option_arc(access: &TokenStream, _tag: u32, inner_ty: &Type) -> TokenStream {
     let decode_new = quote! {
-        let mut __proto_rs_tmp: <::std::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::Shadow<'_> =
-            <::std::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::proto_default();
-        <::std::sync::Arc<#inner_ty> as ::proto_rs::SingularField>::merge_singular_field(
+        let mut __proto_rs_tmp: <::proto_rs::alloc::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::Shadow<'_> =
+            <::proto_rs::alloc::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::proto_default();
+        <::proto_rs::alloc::sync::Arc<#inner_ty> as ::proto_rs::SingularField>::merge_singular_field(
             wire_type,
             &mut __proto_rs_tmp,
             buf,
             ctx.clone(),
         )?;
-        let __proto_rs_owned = <::std::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::post_decode(__proto_rs_tmp)?;
+        let __proto_rs_owned = <::proto_rs::alloc::sync::Arc<#inner_ty> as ::proto_rs::ProtoExt>::post_decode(__proto_rs_tmp)?;
         (#access) = Some(__proto_rs_owned);
     };
 
     quote! {
         if let Some(__proto_rs_existing) = (#access).as_mut() {
-            if let Some(__proto_rs_inner) = ::std::sync::Arc::get_mut(__proto_rs_existing) {
+            if let Some(__proto_rs_inner) = ::proto_rs::alloc::sync::Arc::get_mut(__proto_rs_existing) {
                 <#inner_ty as ::proto_rs::SingularField>::merge_singular_field(
                     wire_type,
                     __proto_rs_inner,

--- a/crates/prosto_derive/src/proto_rpc/client.rs
+++ b/crates/prosto_derive/src/proto_rpc/client.rs
@@ -60,8 +60,8 @@ pub fn generate_client_module(trait_name: &syn::Ident, vis: &syn::Visibility, pa
             where
                 T: tonic::client::GrpcService<tonic::body::Body>,
                 T::Error: Into<StdError>,
-                T::ResponseBody: Body<Data = ::proto_rs::bytes::Bytes> + std::marker::Send + 'static,
-                <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+                T::ResponseBody: Body<Data = ::proto_rs::bytes::Bytes> + ::core::marker::Send + 'static,
+                <T::ResponseBody as Body>::Error: Into<StdError> + ::core::marker::Send,
             {
                 pub fn new(inner: T) -> Self {
                     let inner = tonic::client::Grpc::new(inner);
@@ -109,7 +109,7 @@ fn generate_unary_client_method(method: &MethodInfo, package_name: &str, trait_n
         pub async fn #method_name<R>(
             &mut self,
             request: R,
-        ) -> std::result::Result<tonic::Response<#response_type>, tonic::Status>
+        ) -> ::core::result::Result<tonic::Response<#response_type>, tonic::Status>
         where
             R: ::proto_rs::ProtoRequest<#request_type>,
             ::proto_rs::ProtoEncoder<R::Encode, R::Mode>: ::proto_rs::EncoderExt<R::Encode, R::Mode>,
@@ -144,7 +144,7 @@ fn generate_streaming_client_method(method: &MethodInfo, package_name: &str, tra
         pub async fn #method_name<R>(
             &mut self,
             request: R,
-        ) -> std::result::Result<tonic::Response<impl tonic::codegen::tokio_stream::Stream<Item = Result<#inner_response_type, tonic::Status>>>, tonic::Status>
+        ) -> ::core::result::Result<tonic::Response<impl tonic::codegen::tokio_stream::Stream<Item = ::core::result::Result<#inner_response_type, tonic::Status>>>, tonic::Status>
         where
             R: ::proto_rs::ProtoRequest<#request_type>,
             ::proto_rs::ProtoEncoder<R::Encode, R::Mode>: ::proto_rs::EncoderExt<R::Encode, R::Mode>,

--- a/crates/prosto_derive/src/proto_rpc/rpc_common.rs
+++ b/crates/prosto_derive/src/proto_rpc/rpc_common.rs
@@ -126,7 +126,7 @@ pub fn server_struct_name(trait_name: &syn::Ident) -> syn::Ident {
 /// Generate common service struct fields (used by server)
 pub fn generate_service_struct_fields() -> TokenStream {
     quote! {
-        inner: Arc<T>,
+        inner: ::proto_rs::alloc::sync::Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
@@ -138,10 +138,10 @@ pub fn generate_service_struct_fields() -> TokenStream {
 pub fn generate_service_constructors() -> TokenStream {
     quote! {
         pub fn new(inner: T) -> Self {
-            Self::from_arc(Arc::new(inner))
+            Self::from_arc(::proto_rs::alloc::sync::Arc::new(inner))
         }
 
-        pub fn from_arc(inner: Arc<T>) -> Self {
+        pub fn from_arc(inner: ::proto_rs::alloc::sync::Arc<T>) -> Self {
             Self {
                 inner,
                 accept_compression_encodings: Default::default(),
@@ -164,7 +164,7 @@ pub fn generate_client_with_interceptor(client_struct: &syn::Ident) -> TokenStre
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<http::Request<tonic::body::Body>, Response = http::Response<<T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody>>,
-            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error: Into<StdError> + ::core::marker::Send + ::core::marker::Sync,
         {
             #client_struct::new(InterceptedService::new(inner, interceptor))
         }

--- a/crates/prosto_derive/src/proto_rpc/server.rs
+++ b/crates/prosto_derive/src/proto_rpc/server.rs
@@ -45,14 +45,14 @@ pub fn generate_server_module(trait_name: &syn::Ident, vis: &syn::Visibility, pa
             use tonic::codegen::*;
             use super::*;
 
-            pub trait #trait_name: std::marker::Send + std::marker::Sync + 'static {
+            pub trait #trait_name: ::core::marker::Send + ::core::marker::Sync + 'static {
                 #(#associated_types)*
                 #(#trait_methods)*
             }
 
             impl<T> #trait_name for T
             where
-                T: super::#trait_name + std::marker::Send + std::marker::Sync + 'static,
+                T: super::#trait_name + ::core::marker::Send + ::core::marker::Sync + 'static,
             {
                 #(#blanket_types)*
                 #(#blanket_methods)*
@@ -82,17 +82,17 @@ pub fn generate_server_module(trait_name: &syn::Ident, vis: &syn::Visibility, pa
             impl<T, B> tonic::codegen::Service<http::Request<B>> for #server_struct<T>
             where
                 T: #trait_name,
-                B: Body + std::marker::Send + 'static,
-                B::Error: Into<StdError> + std::marker::Send + 'static,
+                B: Body + ::core::marker::Send + 'static,
+                B::Error: Into<StdError> + ::core::marker::Send + 'static,
             {
                 type Response = http::Response<tonic::body::Body>;
-                type Error = std::convert::Infallible;
-                type Future = impl std::future::Future<Output = std::result::Result<Self::Response, Self::Error>> + std::marker::Send;
+                type Error = ::core::convert::Infallible;
+                type Future = impl ::core::future::Future<Output = ::core::result::Result<Self::Response, Self::Error>> + ::core::marker::Send;
 
                 fn poll_ready(
                     &mut self,
                     _cx: &mut Context<'_>
-                ) -> Poll<std::result::Result<(), Self::Error>> {
+                ) -> Poll<::core::result::Result<(), Self::Error>> {
                     Poll::Ready(Ok(()))
                 }
 
@@ -175,11 +175,11 @@ fn generate_trait_method(method: &MethodInfo) -> TokenStream {
             fn #method_name(
                 &self,
                 request: tonic::Request<#request_proto>,
-            ) -> impl std::future::Future<
-                Output = std::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
-            > + std::marker::Send + '_
+            ) -> impl ::core::future::Future<
+                Output = ::core::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
+            > + ::core::marker::Send + '_
             where
-                Self: std::marker::Send + std::marker::Sync;
+                Self: ::core::marker::Send + ::core::marker::Sync;
         }
     } else {
         let response_type = &method.response_type;
@@ -190,16 +190,16 @@ fn generate_trait_method(method: &MethodInfo) -> TokenStream {
             fn #method_name(
                 &self,
                 request: tonic::Request<#request_proto>,
-            ) -> impl std::future::Future<
-                Output = std::result::Result<
+            ) -> impl ::core::future::Future<
+                Output = ::core::result::Result<
                     tonic::Response<
                         <#response_return_type as ::proto_rs::ProtoResponse<#response_proto>>::Encode
                     >,
                     tonic::Status
                 >
-            > + std::marker::Send + '_
+            > + ::core::marker::Send + '_
             where
-                Self: std::marker::Send + std::marker::Sync;
+                Self: ::core::marker::Send + ::core::marker::Sync;
         }
     }
 }
@@ -210,7 +210,7 @@ fn generate_stream_associated_type(method: &MethodInfo) -> TokenStream {
     let response_proto = generate_response_proto_type(inner_type);
 
     quote! {
-        type #stream_name: tonic::codegen::tokio_stream::Stream<Item = std::result::Result<#response_proto, tonic::Status>> + std::marker::Send + 'static;
+        type #stream_name: tonic::codegen::tokio_stream::Stream<Item = ::core::result::Result<#response_proto, tonic::Status>> + ::core::marker::Send + 'static;
     }
 }
 
@@ -264,14 +264,14 @@ fn generate_blanket_unary_method(method: &MethodInfo, trait_name: &syn::Ident) -
         fn #method_name(
             &self,
             request: tonic::Request<#request_proto>,
-        ) -> impl std::future::Future<
-            Output = std::result::Result<
+        ) -> impl ::core::future::Future<
+            Output = ::core::result::Result<
                 tonic::Response<
                     <#response_return_type as ::proto_rs::ProtoResponse<#response_proto>>::Encode
                 >,
                 tonic::Status
             >
-        > + std::marker::Send + '_ {
+        > + ::core::marker::Send + '_ {
             async move {
                 #request_conversion
 
@@ -302,9 +302,9 @@ fn generate_blanket_streaming_method(method: &MethodInfo, trait_name: &syn::Iden
         fn #method_name(
             &self,
             request: tonic::Request<#request_proto>,
-        ) -> impl std::future::Future<
-            Output = std::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
-        > + std::marker::Send + '_ {
+        ) -> impl ::core::future::Future<
+            Output = ::core::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
+        > + ::core::marker::Send + '_ {
             async move {
                 #request_conversion
 
@@ -359,9 +359,9 @@ fn generate_unary_route_handler(method: &MethodInfo, route_path: &str, svc_name:
 
             impl<T: #trait_name> tonic::server::UnaryService<#request_proto> for #svc_name<T> {
                 type Response = <#response_return_type as ::proto_rs::ProtoResponse<#response_proto>>::Encode;
-                type Future = impl std::future::Future<
-                        Output = std::result::Result<tonic::Response<Self::Response>, tonic::Status>
-                    > + std::marker::Send + 'static;
+                type Future = impl ::core::future::Future<
+                        Output = ::core::result::Result<tonic::Response<Self::Response>, tonic::Status>
+                    > + ::core::marker::Send + 'static;
 
                 fn call(&mut self, request: tonic::Request<#request_proto>) -> Self::Future {
                     let inner = Arc::clone(&self.0);
@@ -408,9 +408,9 @@ fn generate_streaming_route_handler(method: &MethodInfo, route_path: &str, svc_n
             impl<T: #trait_name> tonic::server::ServerStreamingService<#request_proto> for #svc_name<T> {
                 type Response = #response_proto;
                 type ResponseStream = T::#stream_name;
-                type Future = impl std::future::Future<
-                        Output = std::result::Result<tonic::Response<Self::ResponseStream>, tonic::Status>
-                    > + std::marker::Send + 'static;
+                type Future = impl ::core::future::Future<
+                        Output = ::core::result::Result<tonic::Response<Self::ResponseStream>, tonic::Status>
+                    > + ::core::marker::Send + 'static;
 
                 fn call(&mut self, request: tonic::Request<#request_proto>) -> Self::Future {
                     let inner = Arc::clone(&self.0);

--- a/crates/prosto_derive/src/proto_rpc/utils.rs
+++ b/crates/prosto_derive/src/proto_rpc/utils.rs
@@ -7,61 +7,64 @@ use syn::ItemTrait;
 use syn::PatType;
 use syn::ReturnType;
 use syn::TraitItem;
+use syn::TraitItemType;
 use syn::Type;
 use syn::TypePath;
 
 use crate::utils::MethodInfo;
 
+#[derive(Debug)]
+struct ParsedMethodSignature {
+    request_type: Type,
+    response_type: Type,
+    response_return_type: Type,
+    response_is_result: bool,
+    is_streaming: bool,
+    stream_type_name: Option<syn::Ident>,
+    inner_response_type: Option<Type>,
+}
+
+impl ParsedMethodSignature {
+    fn new(sig: &syn::Signature, trait_items: &[TraitItem]) -> Self {
+        let request_type = extract_request_type(sig);
+        let (response_return_type, response_is_result) = extract_response_return(sig);
+        let response_type = extract_proto_type(&response_return_type);
+        let (is_streaming, stream_type_name, inner_response_type) = extract_stream_metadata(&response_type, trait_items);
+
+        Self {
+            request_type,
+            response_type,
+            response_return_type,
+            response_is_result,
+            is_streaming,
+            stream_type_name,
+            inner_response_type,
+        }
+    }
+}
+
 /// Extract methods and associated types from the trait definition
 pub fn extract_methods_and_types(input: &ItemTrait) -> (Vec<MethodInfo>, Vec<TokenStream>) {
-    let mut methods = Vec::new();
+    let mut methods = Vec::with_capacity(input.items.len());
     let mut user_associated_types = Vec::new();
 
     for item in &input.items {
         match item {
             TraitItem::Fn(method) => {
                 let method_name = method.sig.ident.clone();
-                let (request_type, response_type, response_return_type, response_is_result) = extract_types(&method.sig);
-                let is_streaming = is_stream_response(&method.sig);
+                let signature = ParsedMethodSignature::new(&method.sig, &input.items);
 
-                let (stream_type_name, inner_response_type) = if is_streaming {
-                    let stream_name = extract_stream_type_name(&response_type);
-                    let inner_type = input
-                        .items
-                        .iter()
-                        .find_map(|item| {
-                            if let TraitItem::Type(type_item) = item
-                                && type_item.ident == stream_name
-                            {
-                                return Some(extract_inner_type_from_bounds(&type_item.bounds));
-                            }
-                            None
-                        })
-                        .unwrap_or_else(|| panic!("Could not find associated type definition for {stream_name}"));
-                    (Some(stream_name), Some(inner_type))
-                } else {
-                    (None, None)
-                };
-
-                let user_method_signature = generate_user_method_signature(
-                    &method.attrs,
-                    &method_name,
-                    &request_type,
-                    &response_return_type,
-                    response_is_result,
-                    is_streaming,
-                    stream_type_name.as_ref(),
-                );
+                let user_method_signature = generate_user_method_signature(&method.attrs, &method_name, &signature);
 
                 methods.push(MethodInfo {
                     name: method_name,
-                    request_type,
-                    response_type,
-                    response_return_type,
-                    response_is_result,
-                    is_streaming,
-                    stream_type_name,
-                    inner_response_type,
+                    request_type: signature.request_type,
+                    response_type: signature.response_type,
+                    response_return_type: signature.response_return_type,
+                    response_is_result: signature.response_is_result,
+                    is_streaming: signature.is_streaming,
+                    stream_type_name: signature.stream_type_name,
+                    inner_response_type: signature.inner_response_type,
                     user_method_signature,
                 });
             }
@@ -83,138 +86,100 @@ pub fn extract_methods_and_types(input: &ItemTrait) -> (Vec<MethodInfo>, Vec<Tok
 }
 
 /// Generate user-facing method signature for the trait
-fn generate_user_method_signature(
-    attrs: &[syn::Attribute],
-    method_name: &syn::Ident,
-    request_type: &Type,
-    response_return_type: &Type,
-    response_is_result: bool,
-    is_streaming: bool,
-    stream_type_name: Option<&syn::Ident>,
-) -> TokenStream {
-    if is_streaming {
-        let stream_name = stream_type_name.unwrap();
-        quote! {
-            #(#attrs)*
-            fn #method_name(
-                &self,
-                request: tonic::Request<#request_type>,
-            ) -> impl std::future::Future<
-                Output = std::result::Result<tonic::Response<Self::#stream_name>, tonic::Status>
-            > + ::core::marker::Send
-            where
-                Self: std::marker::Send + std::marker::Sync;
-        }
-    } else if response_is_result {
-        quote! {
-            #(#attrs)*
-            fn #method_name(
-                &self,
-                request: tonic::Request<#request_type>,
-            ) -> impl std::future::Future<
-                Output = std::result::Result<#response_return_type, tonic::Status>
-            > + ::core::marker::Send
-            where
-                Self: std::marker::Send + std::marker::Sync;
-        }
+fn generate_user_method_signature(attrs: &[syn::Attribute], method_name: &syn::Ident, signature: &ParsedMethodSignature) -> TokenStream {
+    let future_output = if signature.is_streaming {
+        let stream_name = signature.stream_type_name.as_ref().expect("streaming method must define stream name");
+        quote! { ::core::result::Result<tonic::Response<Self::#stream_name>, tonic::Status> }
+    } else if signature.response_is_result {
+        let response_return_type = &signature.response_return_type;
+        quote! { ::core::result::Result<#response_return_type, tonic::Status> }
     } else {
-        quote! {
-            #(#attrs)*
-            fn #method_name(
-                &self,
-                request: tonic::Request<#request_type>,
-            ) -> impl std::future::Future<
-                Output = #response_return_type
-            > + ::core::marker::Send
-            where
-                Self: std::marker::Send + std::marker::Sync;
-        }
+        let response_return_type = &signature.response_return_type;
+        quote! { #response_return_type }
+    };
+
+    let request_type = &signature.request_type;
+
+    quote! {
+        #(#attrs)*
+        fn #method_name(
+            &self,
+            request: tonic::Request<#request_type>,
+        ) -> impl ::core::future::Future<Output = #future_output> + ::core::marker::Send
+        where
+            Self: ::core::marker::Send + ::core::marker::Sync;
     }
 }
 
-/// Extract request and response types from method signature
-pub fn extract_types(sig: &syn::Signature) -> (Box<Type>, Box<Type>, Box<Type>, bool) {
-    let mut request_type = None;
-    let mut response_type = None;
-    let mut response_return_type = None;
-    let mut response_is_result = false;
-
-    // Extract request type from arguments
-    for arg in &sig.inputs {
-        if let FnArg::Typed(PatType { ty, .. }) = arg
-            && let Type::Path(TypePath { path, .. }) = &**ty
-            && let Some(segment) = path.segments.last()
-            && segment.ident == "Request"
-            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-            && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
-        {
-            request_type = Some(Box::new(inner_ty.clone()));
-        }
-    }
-
-    // Extract response type from return type
-    if let ReturnType::Type(_, ty) = &sig.output {
-        if let Type::Path(TypePath { path, .. }) = &**ty {
-            if let Some(segment) = path.segments.last() {
-                if segment.ident == "Result" {
-                    response_is_result = true;
-                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-                        && let Some(syn::GenericArgument::Type(success_ty)) = args.args.first()
-                    {
-                        response_return_type = Some(Box::new(success_ty.clone()));
-                    }
-                } else {
-                    response_return_type = Some(Box::new((**ty).clone()));
-                }
+fn extract_request_type(sig: &syn::Signature) -> Type {
+    sig.inputs
+        .iter()
+        .find_map(|arg| {
+            if let FnArg::Typed(PatType { ty, .. }) = arg
+                && let Type::Path(TypePath { path, .. }) = &**ty
+                && let Some(segment) = path.segments.last()
+                && segment.ident == "Request"
+                && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+                && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
+            {
+                Some(inner_ty.clone())
+            } else {
+                None
             }
-        } else {
-            response_return_type = Some(Box::new((**ty).clone()));
-        }
-    }
-
-    if let Some(success_ty) = &response_return_type {
-        response_type = Some(extract_proto_type(success_ty));
-    }
-
-    (
-        request_type.expect("Could not extract request type"),
-        response_type.expect("Could not extract response type"),
-        response_return_type.expect("Could not extract response return type"),
-        response_is_result,
-    )
+        })
+        .unwrap_or_else(|| panic!("Could not extract request type"))
 }
 
-fn extract_proto_type(success_ty: &Type) -> Box<Type> {
+fn extract_response_return(sig: &syn::Signature) -> (Type, bool) {
+    if let ReturnType::Type(_, ty) = &sig.output {
+        if let Type::Path(TypePath { path, .. }) = &**ty
+            && let Some(segment) = path.segments.last()
+            && segment.ident == "Result"
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+            && let Some(syn::GenericArgument::Type(success_ty)) = args.args.first()
+        {
+            return (success_ty.clone(), true);
+        }
+
+        return ((**ty).clone(), false);
+    }
+
+    panic!("RPC trait methods must return a type");
+}
+
+fn extract_proto_type(success_ty: &Type) -> Type {
     if let Type::Path(TypePath { path, .. }) = success_ty
         && let Some(segment) = path.segments.last()
         && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
         && (segment.ident == "Response" || segment.ident == "ZeroCopyResponse")
         && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
     {
-        return Box::new(inner_ty.clone());
-    }
-
-    Box::new(success_ty.clone())
-}
-
-/// Check if the response type is a stream
-pub fn is_stream_response(sig: &syn::Signature) -> bool {
-    if let ReturnType::Type(_, ty) = &sig.output {
-        let type_string = quote!(#ty).to_string();
-        type_string.contains("Self ::") && type_string.contains("Stream")
+        inner_ty.clone()
     } else {
-        false
+        success_ty.clone()
     }
 }
 
-/// Extract the stream type name from response type
-pub fn extract_stream_type_name(response_type: &Type) -> syn::Ident {
-    if let Type::Path(TypePath { path, .. }) = response_type
-        && let Some(segment) = path.segments.last()
-    {
-        return segment.ident.clone();
+fn extract_stream_metadata(response_type: &Type, trait_items: &[TraitItem]) -> (bool, Option<syn::Ident>, Option<Type>) {
+    if let Type::Path(TypePath { qself: None, path }) = response_type {
+        let mut segments = path.segments.iter();
+        if let (Some(self_segment), Some(stream_segment)) = (segments.next(), segments.next())
+            && self_segment.ident == "Self"
+        {
+            let stream_name = stream_segment.ident.clone();
+            let inner = find_stream_item_type(&stream_name, trait_items).unwrap_or_else(|| panic!("Could not find associated type definition for {stream_name}"));
+            return (true, Some(stream_name), Some(inner));
+        }
     }
-    panic!("Could not extract stream type name from response type");
+
+    (false, None, None)
+}
+
+fn find_stream_item_type(stream_name: &syn::Ident, trait_items: &[TraitItem]) -> Option<Type> {
+    trait_items.iter().find_map(|item| match item {
+        TraitItem::Type(TraitItemType { ident, bounds, .. }) if ident == stream_name => Some(extract_inner_type_from_bounds(bounds)),
+        _ => None,
+    })
 }
 
 /// Extract inner type from Stream trait bounds
@@ -246,87 +211,65 @@ pub fn extract_inner_type_from_bounds(bounds: &syn::punctuated::Punctuated<syn::
 
 #[cfg(test)]
 mod tests {
+    use syn::ItemTrait;
     use syn::parse_quote;
 
     use super::*;
 
     #[test]
-    fn test_extract_types() {
-        let sig: syn::Signature = parse_quote! {
-            async fn test_method(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> Result<tonic::Response<MyResponse>, tonic::Status>
+    fn test_parsed_method_signature_variants() {
+        let trait_input: ItemTrait = parse_quote! {
+            trait TestService {
+                type MyStream: tonic::codegen::tokio_stream::Stream<Item = Result<MyResponse, tonic::Status>> + Send + 'static;
+
+                async fn unary(
+                    &self,
+                    request: tonic::Request<MyRequest>
+                ) -> Result<tonic::Response<MyResponse>, tonic::Status>;
+
+                async fn zero_copy(
+                    &self,
+                    request: tonic::Request<MyRequest>
+                ) -> Result<proto_rs::ZeroCopyResponse<MyResponse>, tonic::Status>;
+
+                async fn streaming(
+                    &self,
+                    request: tonic::Request<MyRequest>
+                ) -> Result<tonic::Response<Self::MyStream>, tonic::Status>;
+
+                async fn plain(
+                    &self,
+                    request: tonic::Request<MyRequest>
+                ) -> MyResponse;
+            }
         };
 
-        let (req_type, resp_type, return_type, is_result) = extract_types(&sig);
-        assert_eq!(quote!(#req_type).to_string(), "MyRequest");
-        assert_eq!(quote!(#resp_type).to_string(), "MyResponse");
-        assert_eq!(quote!(#return_type).to_string(), "tonic :: Response < MyResponse >");
-        assert!(is_result);
+        let signatures: Vec<_> = trait_input
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                TraitItem::Fn(fun) => Some(ParsedMethodSignature::new(&fun.sig, &trait_input.items)),
+                _ => None,
+            })
+            .collect();
 
-        let sig_plain: syn::Signature = parse_quote! {
-            async fn plain(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> MyResponse
-        };
+        let unary = &signatures[0];
+        assert_eq!(quote!(#unary.request_type).to_string(), "MyRequest");
+        assert_eq!(quote!(#unary.response_type).to_string(), "MyResponse");
+        assert!(unary.response_is_result);
+        assert!(!unary.is_streaming);
 
-        let (_, plain_resp, plain_return, plain_is_result) = extract_types(&sig_plain);
-        assert_eq!(quote!(#plain_resp).to_string(), "MyResponse");
-        assert_eq!(quote!(#plain_return).to_string(), "MyResponse");
-        assert!(!plain_is_result);
+        let zero_copy = &signatures[1];
+        assert_eq!(quote!(#zero_copy.response_return_type).to_string(), "proto_rs :: ZeroCopyResponse < MyResponse >");
+        assert!(zero_copy.response_is_result);
 
-        let sig_zero_copy: syn::Signature = parse_quote! {
-            async fn zero_copy(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> Result<proto_rs::ZeroCopyResponse<MyResponse>, tonic::Status>
-        };
+        let streaming = &signatures[2];
+        assert!(streaming.is_streaming);
+        assert_eq!(streaming.stream_type_name.as_ref().unwrap().to_string(), "MyStream");
+        assert_eq!(quote!(#streaming.inner_response_type.as_ref().unwrap()).to_string(), "MyResponse");
 
-        let (_, zero_copy_resp, zero_copy_return, zero_copy_is_result) = extract_types(&sig_zero_copy);
-        assert_eq!(quote!(#zero_copy_resp).to_string(), "MyResponse");
-        assert_eq!(quote!(#zero_copy_return).to_string(), "proto_rs :: ZeroCopyResponse < MyResponse >");
-        assert!(zero_copy_is_result);
-
-        let sig_result_plain: syn::Signature = parse_quote! {
-            async fn result_plain(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> Result<MyResponse, tonic::Status>
-        };
-
-        let (_, result_plain_resp, result_plain_return, result_plain_is_result) = extract_types(&sig_result_plain);
-        assert_eq!(quote!(#result_plain_resp).to_string(), "MyResponse");
-        assert_eq!(quote!(#result_plain_return).to_string(), "MyResponse");
-        assert!(result_plain_is_result);
-    }
-
-    #[test]
-    fn test_is_stream_response() {
-        let streaming_sig: syn::Signature = parse_quote! {
-            async fn stream_method(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> Result<tonic::Response<Self::MyStream>, tonic::Status>
-        };
-
-        assert!(is_stream_response(&streaming_sig));
-
-        let unary_sig: syn::Signature = parse_quote! {
-            async fn unary_method(
-                &self,
-                request: tonic::Request<MyRequest>
-            ) -> Result<tonic::Response<MyResponse>, tonic::Status>
-        };
-
-        assert!(!is_stream_response(&unary_sig));
-    }
-
-    #[test]
-    fn test_extract_stream_type_name() {
-        let ty: Type = parse_quote! { Self::MyStream };
-        let name = extract_stream_type_name(&ty);
-        assert_eq!(name.to_string(), "MyStream");
+        let plain = &signatures[3];
+        assert!(!plain.response_is_result);
+        assert_eq!(quote!(#plain.response_return_type).to_string(), "MyResponse");
     }
 }

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -151,9 +151,9 @@ pub fn vec_inner_type(ty: &Type) -> Option<Type> {
 
 pub struct MethodInfo {
     pub name: syn::Ident,
-    pub request_type: Box<Type>,
-    pub response_type: Box<Type>,
-    pub response_return_type: Box<Type>,
+    pub request_type: Type,
+    pub response_type: Type,
+    pub response_return_type: Type,
     pub response_is_result: bool,
     pub is_streaming: bool,
     pub stream_type_name: Option<syn::Ident>,

--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -140,7 +140,7 @@ fn parse_array_type(array: &TypeArray) -> ParsedFieldType {
         is_repeated: true,
         is_message_like,
         is_numeric_scalar,
-        proto_rust_type: parse_quote! { ::std::vec::Vec<#inner_proto> },
+        proto_rust_type: parse_quote! { ::proto_rs::alloc::vec::Vec<#inner_proto> },
         elem_type: elem,
         is_rust_enum: inner.is_rust_enum,
         map_kind: None,
@@ -183,7 +183,16 @@ fn parse_vec_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
     };
 
     if matches!(inner_ty, Type::Path(p) if last_ident(p).is_some_and(|id| id == "u8")) {
-        return ParsedFieldType::new(ty.clone(), "bytes", quote! { bytes }, false, false, parse_quote! { ::std::vec::Vec<u8> }, (*inner_ty).clone(), false);
+        return ParsedFieldType::new(
+            ty.clone(),
+            "bytes",
+            quote! { bytes },
+            false,
+            false,
+            parse_quote! { ::proto_rs::alloc::vec::Vec<u8> },
+            (*inner_ty).clone(),
+            false,
+        );
     }
 
     let inner = parse_field_type(inner_ty);
@@ -228,7 +237,16 @@ fn parse_primitive_or_custom(ty: &Type) -> ParsedFieldType {
                     "f32" => ParsedFieldType::new(ty.clone(), "float", quote! { float }, false, true, parse_quote! { f32 }, ty.clone(), false),
                     "f64" => ParsedFieldType::new(ty.clone(), "double", quote! { double }, false, true, parse_quote! { f64 }, ty.clone(), false),
                     "bool" => numeric_scalar(ty.clone(), parse_quote! { bool }, "bool"),
-                    "String" => ParsedFieldType::new(ty.clone(), "string", quote! { string }, false, false, parse_quote! { ::std::string::String }, ty.clone(), false),
+                    "String" => ParsedFieldType::new(
+                        ty.clone(),
+                        "string",
+                        quote! { string },
+                        false,
+                        false,
+                        parse_quote! { ::proto_rs::alloc::string::String },
+                        ty.clone(),
+                        false,
+                    ),
                     "Bytes" => ParsedFieldType::new(ty.clone(), "bytes", quote! { bytes }, false, false, parse_quote! { ::proto_rs::bytes::Bytes }, ty.clone(), false),
                     _ => parse_custom_type(ty),
                 };
@@ -269,7 +287,7 @@ fn parse_map_type(path: &TypePath, ty: &Type, kind: MapKind) -> ParsedFieldType 
     let value_proto_ty = value_info.proto_rust_type.clone();
     let proto_rust_type = match kind {
         MapKind::HashMap => parse_quote! { ::std::collections::HashMap<#key_proto_ty, #value_proto_ty> },
-        MapKind::BTreeMap => parse_quote! { ::alloc::collections::BTreeMap<#key_proto_ty, #value_proto_ty> },
+        MapKind::BTreeMap => parse_quote! { ::proto_rs::alloc::collections::BTreeMap<#key_proto_ty, #value_proto_ty> },
     };
 
     ParsedFieldType {

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -1,7 +1,7 @@
 //! `ProtoExt` implementations for fixed-size arrays using new trait system
 
 use core::array;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 use bytes::Buf;
 use bytes::BufMut;

--- a/src/custom_types/solana/address.rs
+++ b/src/custom_types/solana/address.rs
@@ -44,7 +44,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_key(1, WireType::LengthDelimited, &mut buf);
         encode_varint((BYTES - 1) as u64, &mut buf);
-        buf.extend(std::iter::repeat_n(0u8, BYTES - 1));
+        buf.extend(core::iter::repeat(0u8).take(BYTES - 1));
 
         match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
             Ok(_) => panic!("invalid length should fail"),

--- a/src/custom_types/solana/signature.rs
+++ b/src/custom_types/solana/signature.rs
@@ -44,7 +44,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_key(1, WireType::LengthDelimited, &mut buf);
         encode_varint((BYTES - 2) as u64, &mut buf);
-        buf.extend(std::iter::repeat_n(0u8, BYTES - 2));
+        buf.extend(core::iter::repeat(0u8).take(BYTES - 2));
 
         match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
             Ok(_) => panic!("invalid length should fail"),

--- a/src/encoding/wire_type.rs
+++ b/src/encoding/wire_type.rs
@@ -1,5 +1,6 @@
-use crate::DecodeError;
 use alloc::format;
+
+use crate::DecodeError;
 
 /// Represent the wire type for protobuf encoding.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use alloc::borrow::Cow;
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
 use core::fmt;
 
 /// A Protobuf message decoding error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::cast_lossless)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate self as proto_rs;
 
@@ -31,6 +32,7 @@ pub use bytes;
 
 mod error;
 mod name;
+#[cfg(feature = "std")]
 mod tonic;
 mod traits;
 mod types;
@@ -46,17 +48,29 @@ pub use crate::error::DecodeError;
 pub use crate::error::EncodeError;
 pub use crate::error::UnknownEnumValue;
 pub use crate::name::Name;
+#[cfg(feature = "std")]
 pub use crate::tonic::BytesMode;
+#[cfg(feature = "std")]
 pub use crate::tonic::EncoderExt;
+#[cfg(feature = "std")]
 pub use crate::tonic::ProtoCodec;
+#[cfg(feature = "std")]
 pub use crate::tonic::ProtoEncoder;
+#[cfg(feature = "std")]
 pub use crate::tonic::ProtoRequest;
+#[cfg(feature = "std")]
 pub use crate::tonic::ProtoResponse;
+#[cfg(feature = "std")]
 pub use crate::tonic::SunByRef;
+#[cfg(feature = "std")]
 pub use crate::tonic::SunByVal;
+#[cfg(feature = "std")]
 pub use crate::tonic::ToZeroCopyRequest;
+#[cfg(feature = "std")]
 pub use crate::tonic::ToZeroCopyResponse;
+#[cfg(feature = "std")]
 pub use crate::tonic::ZeroCopyRequest;
+#[cfg(feature = "std")]
 pub use crate::tonic::ZeroCopyResponse;
 pub use crate::traits::MessageField;
 pub use crate::traits::OwnedSunOf;
@@ -71,7 +85,7 @@ pub use crate::traits::ViewOf;
 
 /// Build-time proto schema registry
 /// Only available when "build-schemas" feature is enabled
-#[cfg(feature = "build-schemas")]
+#[cfg(all(feature = "build-schemas", feature = "std"))]
 pub mod schemas {
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
@@ -205,7 +219,7 @@ pub mod schemas {
 }
 
 // Example build.rs that users can copy:
-#[cfg(all(feature = "build-schemas", doc))]
+#[cfg(all(feature = "build-schemas", feature = "std", doc))]
 /// Example build.rs for consuming projects
 ///
 /// ```no_run

--- a/src/tonic/req.rs
+++ b/src/tonic/req.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use tonic::Request;
 

--- a/src/tonic/resp.rs
+++ b/src/tonic/resp.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use tonic::Response;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,10 +1,9 @@
 use bytes::Buf;
 use bytes::BufMut;
 
-use crate::alloc::vec::Vec;
-
 use crate::DecodeError;
 use crate::EncodeError;
+use crate::alloc::vec::Vec;
 use crate::encoding::DecodeContext;
 use crate::encoding::WireType;
 use crate::encoding::decode_key;

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,12 +1,10 @@
 // ---------- imports (adjust for no_std) ----------
-#![cfg_attr(not(feature = "std"), no_std)]
-
 extern crate alloc;
 
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
-use std::mem::MaybeUninit;
-use std::sync::Arc;
+use core::mem::MaybeUninit;
 
 use bytes::Buf;
 use bytes::BufMut;


### PR DESCRIPTION
## Summary
- rewrite proto_rpc utilities to avoid redundant boxing/string parsing and to use core/alloc paths
- adjust generated code to lean on proto_rs::alloc so RPC/message macros work with the std feature gate
- gate tonic helpers behind the std feature and refresh the README to document the new behaviour

## Testing
- cargo fmt
- cargo expand --lib --features std | head -n 40
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f4e221d2888321b9c56342e9bc6449