### PR TITLE
Refine derive macros for leaner generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,10 @@ The test suite exercises more than 400 codec and integration scenarios to ensure
 - `build-schemas` – register generated schemas at compile time so they can be written later.
 - `emit-proto-files` – eagerly write `.proto` files during compilation.
 - `fastnum`, `solana` – enable extra type support.
+- `stable` – compile everything on the stable toolchain by boxing async state. See below for trade-offs.
+
+### Stable vs. nightly builds
+
+The crate defaults to the nightly toolchain so it can use `impl Trait` in associated types for zero-cost futures when deriving RPC services. If you need to stay on stable Rust, enable the `stable` feature. Doing so switches the generated service code to heap-allocate and pin boxed futures, which keeps the API identical but introduces one allocation per RPC invocation and a small amount of dynamic dispatch. Disable the feature when you can use nightly to get the leanest possible generated code.
 
 For the full API surface and macro documentation see [docs.rs/proto_rs](https://docs.rs/proto_rs).

--- a/crates/prosto_derive/src/proto_message.rs
+++ b/crates/prosto_derive/src/proto_message.rs
@@ -21,24 +21,24 @@ pub fn proto_message_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut config = UnifiedProtoConfig::from_attributes(attr, &type_ident, &input.attrs, &input.data);
     let proto_name = config.sun.as_ref().map_or_else(|| type_ident.clone(), |sun| sun.message_ident.clone());
 
-    let (proto, rust_code) = match input.data.clone() {
+    let (proto, rust_code) = match &input.data {
         Data::Struct(data) => {
             let proto = generate_struct_proto(&proto_name, &data.fields);
 
-            let rust_code = struct_handler::handle_struct(input, &data, &config);
+            let rust_code = struct_handler::handle_struct(&input, data, &config);
             (proto, rust_code)
         }
         Data::Enum(data) => {
             let is_simple_enum = data.variants.iter().all(|v| matches!(v.fields, Fields::Unit));
             if is_simple_enum {
-                let proto = generate_simple_enum_proto(&proto_name, &data);
+                let proto = generate_simple_enum_proto(&proto_name, data);
 
-                let rust_code = enum_handler::handle_enum(input, &data);
+                let rust_code = enum_handler::handle_enum(&input, data);
                 (proto, rust_code)
             } else {
-                let proto = generate_complex_enum_proto(&proto_name, &data);
+                let proto = generate_complex_enum_proto(&proto_name, data);
 
-                let rust_code = complex_enum_handler::handle_complex_enum(input, &data);
+                let rust_code = complex_enum_handler::handle_complex_enum(&input, data);
                 (proto, rust_code)
             }
         }

--- a/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
@@ -16,7 +16,7 @@ use super::unified_field_handler::generate_field_encoded_len;
 use crate::utils::find_marked_default_variant;
 use crate::utils::parse_field_config;
 
-pub fn handle_complex_enum(input: DeriveInput, data: &DataEnum) -> TokenStream {
+pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
     let name = &input.ident;
     let attrs: Vec<_> = input.attrs.iter().filter(|a| !a.path().is_ident("proto_message")).collect();
     let vis = &input.vis;

--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -9,7 +9,7 @@ use syn::spanned::Spanned;
 use crate::utils::collect_discriminants_for_variants;
 use crate::utils::find_marked_default_variant;
 
-pub fn handle_enum(input: DeriveInput, data: &DataEnum) -> TokenStream {
+pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
     let name = &input.ident;
     let attrs: Vec<_> = input.attrs.iter().filter(|a| !a.path().is_ident("proto_message")).collect();
     let vis = &input.vis;

--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -17,7 +17,7 @@ use crate::utils::parse_field_config;
 use crate::utils::parse_field_type;
 use crate::utils::vec_inner_type;
 
-pub fn handle_struct(input: DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
+pub fn handle_struct(input: &DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
     match &data.fields {
         Fields::Named(_) => handle_named_struct(input, data, config),
         Fields::Unnamed(_) => handle_tuple_struct(input, data, config),
@@ -55,7 +55,7 @@ fn generate_field_clear(field: &syn::Field, access: &FieldAccess) -> TokenStream
     }
 }
 
-fn handle_unit_struct(input: DeriveInput, config: &UnifiedProtoConfig) -> TokenStream {
+fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> TokenStream {
     let name = &input.ident;
     let attrs = strip_proto_attrs(&input.attrs);
     let vis = &input.vis;
@@ -153,7 +153,7 @@ fn handle_unit_struct(input: DeriveInput, config: &UnifiedProtoConfig) -> TokenS
     }
 }
 
-fn handle_tuple_struct(input: DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
+fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
     let name = &input.ident;
     let attrs = strip_proto_attrs(&input.attrs);
     let vis = &input.vis;
@@ -348,7 +348,7 @@ fn handle_tuple_struct(input: DeriveInput, data: &syn::DataStruct, config: &Unif
     }
 }
 
-fn handle_named_struct(input: DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
+fn handle_named_struct(input: &DeriveInput, data: &syn::DataStruct, config: &UnifiedProtoConfig) -> TokenStream {
     let name = &input.ident;
     let attrs = strip_proto_attrs(&input.attrs);
     let vis = &input.vis;

--- a/crates/prosto_derive/src/proto_rpc.rs
+++ b/crates/prosto_derive/src/proto_rpc.rs
@@ -29,7 +29,7 @@ pub fn proto_rpc_impl(args: TokenStream, item: TokenStream) -> TokenStream2 {
     // Generate .proto file if requested
     let service_content = generate_service_content(trait_name, &methods, &config.type_imports);
     config.register_and_emit_proto(&ty_ident, &service_content);
-    let proto = config.imports_mat;
+    let proto = config.imports_mat.clone();
 
     // Generate user-facing trait
     let user_methods: Vec<_> = methods.iter().map(|m| &m.user_method_signature).collect();

--- a/crates/prosto_derive/src/proto_rpc/utils.rs
+++ b/crates/prosto_derive/src/proto_rpc/utils.rs
@@ -129,7 +129,7 @@ pub(crate) fn associated_future_type(future_output: TokenStream, requires_static
     if cfg!(feature = "stable") {
         quote! {
             ::core::pin::Pin<
-                ::std::boxed::Box<
+                ::proto_rs::alloc::boxed::Box<
                     dyn ::core::future::Future<Output = #future_output>
                         + ::core::marker::Send
                         #static_bound
@@ -145,7 +145,7 @@ pub(crate) fn associated_future_type(future_output: TokenStream, requires_static
 
 pub(crate) fn wrap_async_block(block: TokenStream, boxed: bool) -> TokenStream {
     if boxed && cfg!(feature = "stable") {
-        quote! { ::std::boxed::Box::pin(#block) }
+        quote! { ::proto_rs::alloc::boxed::Box::pin(#block) }
     } else {
         block
     }

--- a/src/custom_types/solana/address.rs
+++ b/src/custom_types/solana/address.rs
@@ -44,7 +44,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_key(1, WireType::LengthDelimited, &mut buf);
         encode_varint((BYTES - 1) as u64, &mut buf);
-        buf.extend(std::iter::repeat_n(0u8, BYTES - 1));
+        buf.extend(core::iter::repeat_n(0u8, BYTES - 1));
 
         match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
             Ok(_) => panic!("invalid length should fail"),

--- a/src/custom_types/solana/signature.rs
+++ b/src/custom_types/solana/signature.rs
@@ -44,7 +44,7 @@ mod tests {
         let mut buf = Vec::new();
         encode_key(1, WireType::LengthDelimited, &mut buf);
         encode_varint((BYTES - 2) as u64, &mut buf);
-        buf.extend(std::iter::repeat_n(0u8, BYTES - 2));
+        buf.extend(core::iter::repeat_n(0u8, BYTES - 2));
 
         match <ByteSeq as ProtoExt>::decode(buf.as_slice()) {
             Ok(_) => panic!("invalid length should fail"),


### PR DESCRIPTION
## Summary
- avoid cloning entire `DeriveInput` values inside `#[proto_message]` expansions by passing shared references into the struct and enum handlers
- generate boxed futures for the stable toolchain via `alloc::boxed::Box` so no-std builds keep compiling while nightly stays zero-cost
- document the `stable` feature trade-off and update Solana helpers to rely on `core` iterators when `std` is disabled

## Testing
- `cargo expand --lib proto_rs::traits::ProtoExt | head -n 20`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68f514d22b0883219e18ba6b4733fe46