### PR TITLE
Document ProtoShadow customization and zero-copy flows

### DIFF
--- a/examples/proto_gen_example.rs
+++ b/examples/proto_gen_example.rs
@@ -3,7 +3,9 @@
 
 use std::pin::Pin;
 
+use proto_rs::ToZeroCopyRequest;
 use proto_rs::ToZeroCopyResponse;
+use proto_rs::ZeroCopyRequest;
 use proto_rs::ZeroCopyResponse;
 use proto_rs::proto_message;
 use proto_rs::proto_rpc;
@@ -134,5 +136,18 @@ mod tests {
         while let Some(v) = res.next().await {
             println!("{:?}", v.unwrap())
         }
+    }
+
+    #[tokio::test]
+    async fn test_zero_copy_client_requests() {
+        let mut client = SigmaRpcClient::connect("http://127.0.0.1:50051").await.unwrap();
+
+        let borrowed = RizzPing {};
+        let zero_copy: ZeroCopyRequest<_> = (&borrowed).to_zero_copy();
+        client.rizz_ping(zero_copy).await.unwrap();
+
+        let request = tonic::Request::new(&borrowed);
+        let zero_copy_with_metadata = request.to_zero_copy();
+        client.rizz_ping(zero_copy_with_metadata).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- describe ProtoShadow-based encode/decode customization in the README with a fastnum example
- document zero-copy server response patterns and client-side request usage
- extend the proto_gen example to exercise borrowed-to-zero-copy client calls

## Testing
- not run (documentation and example updates only)

------
https://chatgpt.com/codex/tasks/task_e_68f51c1fefd08321916810355b9304eb