### PR TITLE
Fix complex enum encoding for oneof messages

### DIFF
--- a/protos/tests/advanced_features.proto
+++ b/protos/tests/advanced_features.proto
@@ -33,11 +33,16 @@ message AdvancedNested {
 }
 
 message AdvancedOriginMissing {}
+message AdvancedOriginDetailed {
+  int32 code = 1;
+  string label = 2;
+}
 message AdvancedOrigin {
   oneof value {
     string raw = 1;
     AdvancedNested nested = 2;
     AdvancedOriginMissing missing = 3;
+    AdvancedOriginDetailed detailed = 4;
   }
 }
 


### PR DESCRIPTION
## Summary
- encode and decode tuple-style complex enum variants using the variant wire type instead of wrapping them in nested messages
- ensure named complex enum variants use the correct field wire types during decoding
- extend the advanced origin fixtures and roundtrip tests with a detailed variant to cover multi-field enum arms

## Testing
- cargo test advanced_roundtrip

------
https://chatgpt.com/codex/tasks/task_e_68f53526cbf08321b6ba474a42a67176