### PR TITLE
Optimize repeated field codegen and inline trait methods

### DIFF
--- a/benches/bench.md
+++ b/benches/bench.md
@@ -1,4 +1,39 @@
 
+# Benchmark Run — 2025-10-20 16:21:11
+
+| Group | Benchmark | Ops / s | MiB/s | Speedup vs Prost |
+| --- | --- | ---: | ---: | ---: |
+| bench_zero_copy_vs_clone | prost clone + encode | 25321.63 | 91.23 | 1.00× |
+| bench_zero_copy_vs_clone | proto_rs zero_copy | 18827.70 | 67.66 | 0.74× slower |
+| complex_root_decode | prost decode canonical input | 19110.68 | 68.86 | 1.00× |
+| complex_root_decode | prost decode proto_rs input | 19104.82 | 68.65 | 1.00× |
+| complex_root_decode | proto_rs decode canonical input | 18697.26 | 67.37 | 0.98× slower |
+| complex_root_decode | proto_rs decode proto_rs input | 18536.10 | 66.61 | 0.97× slower |
+| complex_root_encode | prost encode_to_vec | 64335.10 | 231.80 | 1.00× |
+| complex_root_encode | proto_rs encode_to_vec | 25305.89 | 90.94 | 0.39× slower |
+
+
+# Benchmark Run — 2025-10-20 16:13:54
+
+| Group | Benchmark | Ops / s | MiB/s | Speedup vs Prost |
+| --- | --- | ---: | ---: | ---: |
+| bench_zero_copy_vs_clone | prost clone + encode | 29049.47 | 104.66 | 1.00× |
+| bench_zero_copy_vs_clone | proto_rs zero_copy | 18716.98 | 67.26 | 0.64× slower |
+| complex_root_decode | prost decode canonical input | 17799.00 | 64.13 | 1.00× |
+| complex_root_decode | prost decode proto_rs input | 15412.43 | 55.38 | 1.00× |
+| complex_root_decode | proto_rs decode canonical input | 17618.00 | 63.48 | 0.99× slower |
+| complex_root_decode | proto_rs decode proto_rs input | 18536.34 | 66.61 | 1.20× faster |
+| complex_root_encode | prost encode_to_vec | 70212.41 | 252.97 | 1.00× |
+| complex_root_encode | proto_rs encode_to_vec | 24163.16 | 86.83 | 0.34× slower |
+
+
+# Benchmark Run — 2025-10-20 16:11:56
+
+| Group | Benchmark | Ops / s | MiB/s | Speedup vs Prost |
+| --- | --- | ---: | ---: | ---: |
+| complex_root_decode | proto_rs decode proto_rs input | 20477.72 | 73.59 | 1.00× |
+
+
 # Benchmark Run — 2025-10-20 14:41:01
 
 | Group | Benchmark | Ops / s | MiB/s | Speedup vs Prost |
@@ -83,4 +118,17 @@
 | complex_root_encode | proto_rs encode_to_vec | 0.078947 | 0.39× slower |
 
 
+
+# Benchmark Run — 2025-10-20 16:21:36
+
+| Group | Benchmark | Ops / s | MiB/s | Speedup vs Prost |
+| --- | --- | ---: | ---: | ---: |
+| complex_root_encode | prost encode_to_vec | 64,234.33 | 231.44 | 1.00× |
+| complex_root_encode | proto_rs encode_to_vec | 25,077.11 | 90.11 | 0.39× slower |
+| complex_root_decode | prost decode proto_rs input | 19,181.71 | 68.93 | 1.00× |
+| complex_root_decode | proto_rs decode proto_rs input | 18,331.81 | 65.88 | 0.96× slower |
+| complex_root_decode | prost decode prost input | 19,266.34 | 69.42 | 1.00× |
+| complex_root_decode | proto_rs decode prost input | 19,008.52 | 68.49 | 0.99× slower |
+| bench_zero_copy_vs_clone | prost clone + encode | 26,006.45 | 93.70 | 1.00× |
+| bench_zero_copy_vs_clone | proto_rs zero_copy | 24,510.40 | 88.08 | 0.94× slower |
 

--- a/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
@@ -133,6 +133,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 #default_value
             }
 
+            #[inline]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 let value: &Self = *value;
                 match value {
@@ -140,6 +141,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 let value: &Self = value;
                 match value {
@@ -147,6 +149,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -161,6 +164,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline]
             fn clear(&mut self) {
                 *self = Self::proto_default();
             }

--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -129,6 +129,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 Self::#default_variant_ident
             }
 
+            #[inline]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 let value: &Self = *value;
                 let raw = *value as i32;
@@ -139,6 +140,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 let value: &Self = value;
                 let raw = *value as i32;
@@ -147,6 +149,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -166,6 +169,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline]
             fn clear(&mut self) {
                 *self = Self::proto_default();
             }

--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -103,6 +103,7 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
 
     let clear_impl = if config.sun.is_some() {
         quote! {
+            #[inline]
             fn clear(&mut self) {
                 if let Ok(default) = Self::post_decode(Self::proto_default()) {
                     *self = default;
@@ -110,7 +111,10 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
             }
         }
     } else {
-        quote! { fn clear(&mut self) {} }
+        quote! {
+            #[inline]
+            fn clear(&mut self) {}
+        }
     };
 
     quote! {
@@ -127,15 +131,18 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
                 #name
             }
 
+            #[inline]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 #encoded_len_binding
                 0
             }
 
+            #[inline]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, _buf: &mut impl ::proto_rs::bytes::BufMut) {
                 #encode_binding
             }
 
+            #[inline]
             fn merge_field(
                 _value: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -287,6 +294,7 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
 
     let clear_impl = if config.sun.is_some() {
         quote! {
+            #[inline]
             fn clear(&mut self) {
                 if let Ok(default) = Self::post_decode(Self::proto_default()) {
                     *self = default;
@@ -295,6 +303,7 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         }
     } else {
         quote! {
+            #[inline]
             fn clear(&mut self) {
                 #(#clear_fields)*
             }
@@ -315,16 +324,19 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
                 #shadow_ty(#(#default_values),*)
             }
 
+            #[inline]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 #encoded_len_binding
                 0 #(+ #encoded_len_fields)*
             }
 
+            #[inline]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 #encode_binding
                 #(#encode_fields)*
             }
 
+            #[inline]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -428,12 +428,10 @@ fn encode_array(access: &TokenStream, tag: u32, array: &syn::TypeArray) -> Token
     if elem_parsed.is_message_like {
         return quote! {{
             if !#all_default {
-                let __proto_rs_views = (#access)
-                    .iter()
-                    .map(|value| {
-                        <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-                    });
-                <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views, buf);
+                for __proto_rs_value in (#access).iter() {
+                    let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+                    ::proto_rs::encoding::message::encode::<#elem_ty>(#tag, __proto_rs_view, buf);
+                }
             }
         }};
     }
@@ -495,12 +493,10 @@ fn encode_array(access: &TokenStream, tag: u32, array: &syn::TypeArray) -> Token
 
     quote! {{
         if !#all_default {
-            let __proto_rs_views = (#access)
-                .iter()
-                .map(|value| {
-                    <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-                });
-            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views, buf);
+            for __proto_rs_value in (#access).iter() {
+                let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+                <#elem_ty as ::proto_rs::SingularField>::encode_singular_field(#tag, __proto_rs_view, buf);
+            }
         }
     }}
 }
@@ -654,12 +650,12 @@ fn encoded_len_array(access: &TokenStream, tag: u32, array: &syn::TypeArray) -> 
                 if #all_default {
                     0
                 } else {
-                    let __proto_rs_views = (#access)
-                        .iter()
-                        .map(|value| {
-                            <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-                        });
-                    <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, __proto_rs_views)
+                    let mut __proto_rs_total = 0usize;
+                    for __proto_rs_value in (#access).iter() {
+                        let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+                        __proto_rs_total += <#elem_ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &__proto_rs_view);
+                    }
+                    __proto_rs_total
                 }
             }},
             true,
@@ -703,12 +699,12 @@ fn encoded_len_array(access: &TokenStream, tag: u32, array: &syn::TypeArray) -> 
             if #all_default {
                 0
             } else {
-                let __proto_rs_views = (#access)
-                    .iter()
-                    .map(|value| {
-                        <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-                    });
-                <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, __proto_rs_views)
+                let mut __proto_rs_total = 0usize;
+                for __proto_rs_value in (#access).iter() {
+                    let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+                    __proto_rs_total += <#elem_ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &__proto_rs_view);
+                }
+                __proto_rs_total
             }
         }},
         true,
@@ -773,11 +769,9 @@ fn encode_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> 
     }
 
     quote! {
-        {
-            let __proto_rs_views = (#access).iter().map(|value| {
-                <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-            });
-            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views, buf);
+        for __proto_rs_value in (#access).iter() {
+            let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+            <#elem_ty as ::proto_rs::SingularField>::encode_singular_field(#tag, __proto_rs_view, buf);
         }
     }
 }
@@ -825,12 +819,12 @@ fn encoded_len_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType
     }
 
     quote! {{
-        let __proto_rs_views = (#access)
-            .iter()
-            .map(|value| {
-                <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-            });
-        <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, __proto_rs_views)
+        let mut __proto_rs_total = 0usize;
+        for __proto_rs_value in (#access).iter() {
+            let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+            __proto_rs_total += <#elem_ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &__proto_rs_view);
+        }
+        __proto_rs_total
     }}
 }
 
@@ -947,11 +941,9 @@ fn encode_set(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> Token
     }
 
     quote! {{
-        if !(#access).is_empty() {
-            let __proto_rs_views = (#access).iter().map(|value| {
-                <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-            });
-            <#elem_ty as ::proto_rs::RepeatedField>::encode_repeated_field(#tag, __proto_rs_views, buf);
+        for __proto_rs_value in (#access).iter() {
+            let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+            <#elem_ty as ::proto_rs::SingularField>::encode_singular_field(#tag, __proto_rs_view, buf);
         }
     }}
 }
@@ -1003,12 +995,12 @@ fn encoded_len_set(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> 
     }
 
     quote! {{
-        let __proto_rs_views = (#access)
-            .iter()
-            .map(|value| {
-                <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(value)
-            });
-        <#elem_ty as ::proto_rs::RepeatedField>::encoded_len_repeated_field(#tag, __proto_rs_views)
+        let mut __proto_rs_total = 0usize;
+        for __proto_rs_value in (#access).iter() {
+            let __proto_rs_view = <<#elem_ty as ::proto_rs::ProtoExt>::Shadow<'_> as ::proto_rs::ProtoShadow>::from_sun(__proto_rs_value);
+            __proto_rs_total += <#elem_ty as ::proto_rs::SingularField>::encoded_len_singular_field(#tag, &__proto_rs_view);
+        }
+        __proto_rs_total
     }}
 }
 


### PR DESCRIPTION
## Summary
- replace generated repeated field array and set encoders with explicit loops that reuse message helpers instead of iterator chains
- mark generated `ProtoExt` methods with `#[inline]` across struct and enum handlers to encourage monomorphization
- record refreshed benchmark numbers after the codegen changes

## Testing
- cargo fmt
- cargo check
- cargo expand -p bench_runner --bench main_bench
- cargo bench -p bench_runner

------
https://chatgpt.com/codex/tasks/task_e_68f658cb7ff88321945fa6c0ce87e245