### PR TITLE
Align generated encoding with prost-style helpers

### DIFF
--- a/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enum_handler.rs
@@ -128,11 +128,12 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
         impl #generics ::proto_rs::ProtoExt for #name #generics {
             type Shadow<'a> = Self;
 
-            #[inline]
+            #[inline(always)]
             fn proto_default<'a>() -> Self::Shadow<'a> {
                 #default_value
             }
 
+            #[inline(always)]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 let value: &Self = *value;
                 match value {
@@ -140,6 +141,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline(always)]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 let value: &Self = value;
                 match value {
@@ -147,6 +149,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline(always)]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -161,6 +164,7 @@ pub fn handle_complex_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream 
                 }
             }
 
+            #[inline(always)]
             fn clear(&mut self) {
                 *self = Self::proto_default();
             }

--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -124,11 +124,12 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
         impl #generics ::proto_rs::ProtoExt for #name #generics {
             type Shadow<'a> = Self;
 
-            #[inline]
+            #[inline(always)]
             fn proto_default<'a>() -> Self::Shadow<'a> {
                 Self::#default_variant_ident
             }
 
+            #[inline(always)]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 let value: &Self = *value;
                 let raw = *value as i32;
@@ -139,6 +140,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline(always)]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 let value: &Self = value;
                 let raw = *value as i32;
@@ -147,6 +149,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline(always)]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -166,6 +169,7 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
+            #[inline(always)]
             fn clear(&mut self) {
                 *self = Self::proto_default();
             }

--- a/crates/prosto_derive/src/proto_message/struct_handler.rs
+++ b/crates/prosto_derive/src/proto_message/struct_handler.rs
@@ -103,6 +103,7 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
 
     let clear_impl = if config.sun.is_some() {
         quote! {
+            #[inline(always)]
             fn clear(&mut self) {
                 if let Ok(default) = Self::post_decode(Self::proto_default()) {
                     *self = default;
@@ -110,7 +111,10 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
             }
         }
     } else {
-        quote! { fn clear(&mut self) {} }
+        quote! {
+            #[inline(always)]
+            fn clear(&mut self) {}
+        }
     };
 
     quote! {
@@ -122,20 +126,23 @@ fn handle_unit_struct(input: &DeriveInput, config: &UnifiedProtoConfig) -> Token
         impl #generics ::proto_rs::ProtoExt for #target_ty {
             type Shadow<'a> = #shadow_ty;
 
-            #[inline]
+            #[inline(always)]
             fn proto_default<'a>() -> Self::Shadow<'a> {
                 #name
             }
 
+            #[inline(always)]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 #encoded_len_binding
                 0
             }
 
+            #[inline(always)]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, _buf: &mut impl ::proto_rs::bytes::BufMut) {
                 #encode_binding
             }
 
+            #[inline(always)]
             fn merge_field(
                 _value: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -238,6 +245,7 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         quote! {}
     } else {
         quote! {
+            #[inline(always)]
             fn post_decode(mut shadow: Self::Shadow<'_>) -> Result<Self, ::proto_rs::DecodeError> {
                 #(#post_decode_hooks)*
                 ::proto_rs::ProtoShadow::to_sun(shadow)
@@ -287,6 +295,7 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
 
     let clear_impl = if config.sun.is_some() {
         quote! {
+            #[inline(always)]
             fn clear(&mut self) {
                 if let Ok(default) = Self::post_decode(Self::proto_default()) {
                     *self = default;
@@ -295,6 +304,7 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         }
     } else {
         quote! {
+            #[inline(always)]
             fn clear(&mut self) {
                 #(#clear_fields)*
             }
@@ -310,21 +320,24 @@ fn handle_tuple_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         impl #generics ::proto_rs::ProtoExt for #target_ty {
             type Shadow<'a> = #shadow_ty;
 
-            #[inline]
+            #[inline(always)]
             fn proto_default<'a>() -> Self::Shadow<'a> {
                 #shadow_ty(#(#default_values),*)
             }
 
+            #[inline(always)]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 #encoded_len_binding
                 0 #(+ #encoded_len_fields)*
             }
 
+            #[inline(always)]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 #encode_binding
                 #(#encode_fields)*
             }
 
+            #[inline(always)]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,
@@ -453,6 +466,7 @@ fn handle_named_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         quote! {}
     } else {
         quote! {
+            #[inline(always)]
             fn post_decode(mut shadow: Self::Shadow<'_>) -> Result<Self, ::proto_rs::DecodeError> {
                 #(#post_decode_hooks)*
                 ::proto_rs::ProtoShadow::to_sun(shadow)
@@ -530,23 +544,26 @@ fn handle_named_struct(input: &DeriveInput, data: &syn::DataStruct, config: &Uni
         impl #generics ::proto_rs::ProtoExt for #target_ty {
             type Shadow<'a> = #shadow_ty;
 
-            #[inline]
+            #[inline(always)]
             fn proto_default<'a>() -> Self::Shadow<'a> {
                 #shadow_ty {
                     #(#default_field_values),*
                 }
             }
 
+            #[inline(always)]
             fn encoded_len(value: &::proto_rs::ViewOf<'_, Self>) -> usize {
                 #encoded_len_binding
                 0 #(+ #encoded_len_fields)*
             }
 
+            #[inline(always)]
             fn encode_raw(value: ::proto_rs::ViewOf<'_, Self>, buf: &mut impl ::proto_rs::bytes::BufMut) {
                 #encode_binding
                 #(#encode_fields)*
             }
 
+            #[inline(always)]
             fn merge_field(
                 shadow: &mut Self::Shadow<'_>,
                 tag: u32,


### PR DESCRIPTION
## Summary
- refactor the unified field handler to share prost-style encode/encoded_len helpers for scalars, options, maps, and conversions
- mark generated ProtoExt implementations and core encoding helpers with `#[inline(always)]` to reduce call overhead

## Testing
- cargo test --test encoding_roundtrip


------
https://chatgpt.com/codex/tasks/task_e_68f66f4fb5d88321869f7c1653f7660f