### PR TITLE
Improve repeated field handling performance

### DIFF
--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -217,12 +217,15 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
-            fn merge_repeated_field(
+            fn merge_repeated_field<C>(
                 wire_type: ::proto_rs::encoding::WireType,
-                values: &mut ::proto_rs::alloc::vec::Vec<Self::Shadow<'_>>,
+                values: &mut C,
                 buf: &mut impl ::proto_rs::bytes::Buf,
                 ctx: ::proto_rs::encoding::DecodeContext,
-            ) -> Result<(), ::proto_rs::DecodeError> {
+            ) -> Result<(), ::proto_rs::DecodeError>
+            where
+                C: ::proto_rs::RepeatedCollection<Self>,
+            {
                 if wire_type == ::proto_rs::encoding::WireType::LengthDelimited {
                     ::proto_rs::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
                         let mut raw: i32 = 0;

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -809,24 +809,11 @@ fn encode_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> 
             return quote! {};
         };
 
-        if !needs_numeric_widening(parsed) {
-            return quote! {
-                if !(#access).is_empty() {
-                    ::proto_rs::encoding::#codec::encode_packed(#tag, &(#access), buf);
-                }
-            };
-        }
-
-        let proto_ty = &parsed.proto_rust_type;
-        return quote! {{
+        return quote! {
             if !(#access).is_empty() {
-                let __proto_rs_converted: ::proto_rs::alloc::vec::Vec<#proto_ty> = (#access)
-                    .iter()
-                    .map(|value| (*value) as #proto_ty)
-                    .collect();
-                ::proto_rs::encoding::#codec::encode_packed(#tag, &__proto_rs_converted, buf);
+                ::proto_rs::encoding::#codec::encode_packed(#tag, &(#access), buf);
             }
-        }};
+        };
     }
 
     quote! {
@@ -880,28 +867,13 @@ fn encoded_len_repeated(access: &TokenStream, tag: u32, parsed: &ParsedFieldType
             return quote! { 0 };
         };
 
-        if !needs_numeric_widening(parsed) {
-            return quote! {
-                if (#access).is_empty() {
-                    0
-                } else {
-                    ::proto_rs::encoding::#codec::encoded_len_packed(#tag, &(#access))
-                }
-            };
-        }
-
-        let proto_ty = &parsed.proto_rust_type;
-        return quote! {{
+        return quote! {
             if (#access).is_empty() {
                 0
             } else {
-                let __proto_rs_converted: ::proto_rs::alloc::vec::Vec<#proto_ty> = (#access)
-                    .iter()
-                    .map(|value| (*value) as #proto_ty)
-                    .collect();
-                ::proto_rs::encoding::#codec::encoded_len_packed(#tag, &__proto_rs_converted)
+                ::proto_rs::encoding::#codec::encoded_len_packed(#tag, &(#access))
             }
-        }};
+        };
     }
 
     quote! {{
@@ -1097,16 +1069,12 @@ fn encode_set(access: &TokenStream, tag: u32, parsed: &ParsedFieldType) -> Token
 fn decode_set(access: &TokenStream, _tag: u32, parsed: &ParsedFieldType) -> TokenStream {
     let elem_ty = &parsed.elem_type;
     quote! {
-        let mut __tmp: ::proto_rs::alloc::vec::Vec<#elem_ty> = ::proto_rs::alloc::vec::Vec::new();
         <#elem_ty as ::proto_rs::ProtoExt>::merge_repeated_field(
             wire_type,
-            &mut __tmp,
+            &mut (#access),
             buf,
             ctx.clone(),
         )?;
-        for __value in __tmp {
-            (#access).insert(__value);
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub use crate::traits::OwnedSunOf;
 pub use crate::traits::ProtoEnum;
 pub use crate::traits::ProtoExt;
 pub use crate::traits::ProtoShadow;
+pub use crate::traits::RepeatedCollection;
 pub use crate::traits::Shadow;
 pub use crate::traits::SunOf;
 pub use crate::traits::ViewOf;


### PR DESCRIPTION
## Summary
- avoid temporary allocations when encoding repeated numeric fields by widening inside the encoding helpers
- add a reusable `RepeatedCollection` trait so decode paths can target vectors, sets, and other containers without intermediate buffers
- switch set decoding to use the new trait directly and re-export it for macro-generated code

## Testing
- `cargo test --features tonic`

------
https://chatgpt.com/codex/tasks/task_e_68f6a3c54e9483219f83da4bc0719bd8