### PR TITLE
Refactor repeated field handling

### DIFF
--- a/crates/prosto_derive/src/proto_message/enum_handler.rs
+++ b/crates/prosto_derive/src/proto_message/enum_handler.rs
@@ -202,67 +202,6 @@ pub fn handle_enum(input: &DeriveInput, data: &DataEnum) -> TokenStream {
                 }
             }
 
-            fn encode_repeated_field<'a, I>(
-                tag: u32,
-                values: I,
-                buf: &mut impl ::proto_rs::bytes::BufMut,
-            )
-            where
-                Self: 'a,
-                I: ::core::iter::IntoIterator<Item = ::proto_rs::ViewOf<'a, Self>>,
-            {
-                for value in values {
-                    let raw = (*value) as i32;
-                    ::proto_rs::encoding::int32::encode(tag, &raw, buf);
-                }
-            }
-
-            fn merge_repeated_field<C>(
-                wire_type: ::proto_rs::encoding::WireType,
-                values: &mut C,
-                buf: &mut impl ::proto_rs::bytes::Buf,
-                ctx: ::proto_rs::encoding::DecodeContext,
-            ) -> Result<(), ::proto_rs::DecodeError>
-            where
-                C: ::proto_rs::RepeatedCollection<Self>,
-            {
-                if wire_type == ::proto_rs::encoding::WireType::LengthDelimited {
-                    ::proto_rs::encoding::merge_loop(values, buf, ctx, |values, buf, ctx| {
-                        let mut raw: i32 = 0;
-                        ::proto_rs::encoding::int32::merge(
-                            ::proto_rs::encoding::WireType::Varint,
-                            &mut raw,
-                            buf,
-                            ctx,
-                        )?;
-                        values.push(Self::try_from(raw)?);
-                        Ok(())
-                    })
-                } else {
-                    ::proto_rs::encoding::check_wire_type(
-                        ::proto_rs::encoding::WireType::Varint,
-                        wire_type,
-                    )?;
-                    let mut raw: i32 = 0;
-                    ::proto_rs::encoding::int32::merge(wire_type, &mut raw, buf, ctx)?;
-                    values.push(Self::try_from(raw)?);
-                    Ok(())
-                }
-            }
-
-            fn encoded_len_repeated_field<'a, I>(tag: u32, values: I) -> usize
-            where
-                Self: 'a,
-                I: IntoIterator<Item = ::proto_rs::ViewOf<'a, Self>>,
-            {
-                values
-                    .into_iter()
-                    .map(|value| {
-                        let raw = (*value) as i32;
-                        ::proto_rs::encoding::int32::encoded_len(tag, &raw)
-                    })
-                    .sum()
-            }
         }
 
         impl #generics TryFrom<i32> for #name #generics {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -204,37 +204,6 @@ pub trait ProtoExt: Sized {
         value.as_ref().map_or(0, |inner| Self::encoded_len_singular_field(tag, inner))
     }
 
-    #[inline(always)]
-    fn encode_repeated_field<'a, I>(tag: u32, values: I, buf: &mut impl BufMut)
-    where
-        Self: 'a,
-        I: IntoIterator<Item = ViewOf<'a, Self>>,
-    {
-        for value in values {
-            Self::encode_singular_field(tag, value, buf);
-        }
-    }
-    #[inline(always)]
-    fn merge_repeated_field<C>(wire_type: WireType, values: &mut C, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError>
-    where
-        C: RepeatedCollection<Self>,
-    {
-        let mut value = Self::proto_default();
-        Self::merge_singular_field(wire_type, &mut value, buf, ctx)?;
-        let owned = Self::post_decode(value)?;
-        values.push(owned);
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn encoded_len_repeated_field<'a, I>(tag: u32, values: I) -> usize
-    where
-        Self: 'a,
-        I: IntoIterator<Item = ViewOf<'a, Self>>,
-    {
-        values.into_iter().map(|value| Self::encoded_len_singular_field(tag, &value)).sum()
-    }
-
     fn clear(&mut self);
 }
 /// Marker trait for enums encoded as plain `int32` values on the wire.


### PR DESCRIPTION
## Summary
- remove repeated-field helper methods from the `ProtoExt` trait and associated type impls
- inline repeated/set encoding and decoding in the derive macros using existing encoding modules
- stop generating repeated-field overrides for enums and arrays

## Testing
- `cargo test --package proto_rs --test encoding_roundtrip --all-features --  --show-output`


------
https://chatgpt.com/codex/tasks/task_e_68f76bd05c9483218809750a7ec6bacf