### PR TITLE
Fix decoding for packed narrow numeric collections

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -269,6 +269,13 @@ macro_rules! impl_narrow_varint {
                 }
             }
 
+            fn merge_length_delimited(value: &mut Self::Shadow<'_>, mut buf: impl Buf) -> Result<(), DecodeError> {
+                let mut widened: $wide_ty = <$wide_ty as Default>::default();
+                $module::merge(WireType::Varint, &mut widened, &mut buf, DecodeContext::default())?;
+                *value = widened.try_into().map_err(|_| DecodeError::new($err))?;
+                Ok(())
+            }
+
             fn clear(&mut self) {
                 *self = Self::default();
             }


### PR DESCRIPTION
## Summary
- decode packed repeated fields with narrow numeric element types via `ProtoExt::decode_length_delimited`
- extend narrow varint `ProtoExt` impls to handle length-delimited merges for packed decoding

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68f77c155fb483218c168a4efbad94d9