### PR TITLE
Fix proto_message attribute handling

### DIFF
--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -7,10 +7,13 @@ use syn::Field;
 use syn::Ident;
 use syn::ItemEnum;
 use syn::Type;
+use syn::parse_quote;
+use syn::parse_str;
 use syn::spanned::Spanned;
 
 use crate::utils::FieldConfig;
 use crate::utils::is_option_type;
+use crate::utils::vec_inner_type;
 
 #[derive(Clone)]
 pub struct FieldInfo<'a> {
@@ -66,19 +69,8 @@ pub fn assign_tags(mut fields: Vec<FieldInfo<'_>>) -> Vec<FieldInfo<'_>> {
 
     for info in &mut fields {
         if info.config.skip {
+            info.tag = None;
             continue;
-        }
-
-        if info.config.into_type.is_some()
-            || info.config.from_type.is_some()
-            || info.config.into_fn.is_some()
-            || info.config.from_fn.is_some()
-            || info.config.skip_deser_fn.is_some()
-            || info.config.is_rust_enum
-            || info.config.is_message
-            || info.config.is_proto_enum
-        {
-            panic!("proto_message rewrite does not yet support advanced field attributes");
         }
 
         let tag = if let Some(custom) = info.config.custom_tag {
@@ -129,23 +121,19 @@ pub struct EncodeBinding {
 }
 
 pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> EncodeBinding {
-    let ty = &field.field.ty;
+    let wire_ty = field_wire_type(field);
     let binding_ident = Ident::new(&format!("__proto_rs_field_{}_input", field.index), field.field.span());
     let access_expr = match &field.access {
         FieldAccess::Direct(tokens) => tokens.clone(),
         _ => field.access.access_tokens(base.clone()),
     };
 
-    let init_expr = if is_option_type(ty) {
-        quote! { (#access_expr).as_ref().map(|inner| inner) }
-    } else if matches!(field.access, FieldAccess::Direct(_)) || is_value_encode_type(ty) {
-        access_expr.clone()
-    } else {
-        quote! { &(#access_expr) }
-    };
+    let value_expr = encode_value_expr(field, access_expr);
+
+    let init_expr = encode_input_expr(&wire_ty, value_expr);
 
     let init = quote! {
-        let #binding_ident: <#ty as ::proto_rs::ProtoWire>::EncodeInput<'_> = #init_expr;
+        let #binding_ident: <#wire_ty as ::proto_rs::ProtoWire>::EncodeInput<'_> = #init_expr;
     };
 
     EncodeBinding { init, ident: binding_ident }
@@ -170,14 +158,15 @@ pub fn build_proto_default_expr(fields: &[FieldInfo<'_>]) -> TokenStream2 {
     if fields.iter().all(|f| matches!(f.access, FieldAccess::Tuple(_))) {
         let defaults = fields.iter().map(|info| {
             let ty = &info.field.ty;
-            quote! { <#ty as ::proto_rs::ProtoWire>::proto_default() }
+            default_expr_for_field(info, ty)
         });
         quote! { Self( #(#defaults),* ) }
     } else {
         let defaults = fields.iter().map(|info| {
             let ident = info.access.ident().expect("expected named field");
             let ty = &info.field.ty;
-            quote! { #ident: <#ty as ::proto_rs::ProtoWire>::proto_default() }
+            let value = default_expr_for_field(info, ty);
+            quote! { #ident: #value }
         });
         quote! { Self { #(#defaults),* } }
     }
@@ -189,7 +178,11 @@ pub fn build_clear_stmts(fields: &[FieldInfo<'_>], self_tokens: &TokenStream2) -
         .map(|info| {
             let access = info.access.access_tokens(self_tokens.clone());
             let ty = &info.field.ty;
-            quote! { <#ty as ::proto_rs::ProtoWire>::clear(&mut #access) }
+            if needs_manual_handling(info) {
+                quote! { #access = ::core::default::Default::default() }
+            } else {
+                quote! { <#ty as ::proto_rs::ProtoWire>::clear(&mut #access) }
+            }
         })
         .collect()
 }
@@ -199,14 +192,14 @@ pub fn build_is_default_checks(fields: &[FieldInfo<'_>], base: &TokenStream2) ->
         .iter()
         .filter_map(|info| {
             info.tag?;
-            let ty = &info.field.ty;
+            let wire_ty = field_wire_type(info);
             let binding = encode_input_binding(info, base);
             let ident = binding.ident;
             let init = binding.init;
             Some(quote! {
                 {
                     #init
-                    if !<#ty as ::proto_rs::ProtoWire>::is_default_impl(&#ident) {
+                    if !<#wire_ty as ::proto_rs::ProtoWire>::is_default_impl(&#ident) {
                         return false;
                     }
                 }
@@ -220,13 +213,13 @@ pub fn build_encoded_len_terms(fields: &[FieldInfo<'_>], base: &TokenStream2) ->
         .iter()
         .filter_map(|info| {
             let tag = info.tag?;
-            let ty = &info.field.ty;
+            let wire_ty = field_wire_type(info);
             let binding = encode_input_binding(info, base);
             let ident = binding.ident;
             let init = binding.init;
             Some(quote! {{
                 #init
-                <#ty as ::proto_rs::ProtoWire>::encoded_len_tagged_impl(&#ident, #tag)
+                <#wire_ty as ::proto_rs::ProtoWire>::encoded_len_tagged_impl(&#ident, #tag)
             }})
         })
         .collect()
@@ -237,18 +230,188 @@ pub fn build_encode_stmts(fields: &[FieldInfo<'_>], base: &TokenStream2) -> Vec<
         .iter()
         .filter_map(|info| {
             let tag = info.tag?;
-            let ty = &info.field.ty;
+            let wire_ty = field_wire_type(info);
             let binding = encode_input_binding(info, base);
             let ident = binding.ident;
             let init = binding.init;
             Some(quote! {
                 {
                     #init
-                    if let Err(err) = <#ty as ::proto_rs::ProtoWire>::encode_with_tag(#tag, #ident, buf) {
+                    if let Err(err) = <#wire_ty as ::proto_rs::ProtoWire>::encode_with_tag(#tag, #ident, buf) {
                         panic!("encode_raw_unchecked called without sufficient capacity: {err}");
                     }
                 }
             })
         })
         .collect()
+}
+
+pub fn build_decode_arm(info: &FieldInfo<'_>, access: TokenStream2) -> TokenStream2 {
+    let wire_ty = field_wire_type(info);
+
+    if needs_conversion(info) {
+        let tmp_ident = Ident::new(&format!("__proto_rs_field_{}_tmp", info.index), info.field.span());
+        let assign_tokens = build_decode_assignment(info, &tmp_ident, access.clone(), &wire_ty);
+        quote! {{
+            let mut #tmp_ident: #wire_ty = <#wire_ty as ::proto_rs::ProtoWire>::proto_default();
+            <#wire_ty as ::proto_rs::ProtoWire>::decode_into(wire_type, &mut #tmp_ident, buf, ctx)?;
+            #assign_tokens
+            Ok(())
+        }}
+    } else {
+        quote! {
+            <#wire_ty as ::proto_rs::ProtoWire>::decode_into(
+                wire_type,
+                &mut #access,
+                buf,
+                ctx,
+            )
+        }
+    }
+}
+
+pub fn build_post_decode_impl(fields: &[FieldInfo<'_>]) -> TokenStream2 {
+    let hooks = fields
+        .iter()
+        .filter_map(|info| {
+            if info.config.skip {
+                if let Some(fun) = &info.config.skip_deser_fn {
+                    let path: syn::Path = parse_str(fun).expect("invalid #[proto(skip = \"...\")] function path");
+                    let access = info.access.access_tokens(quote! { shadow });
+                    Some(quote! {
+                        {
+                            let __proto_rs_tmp = #path(&mut shadow);
+                            #access = __proto_rs_tmp;
+                        }
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if hooks.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            #[inline(always)]
+            fn post_decode(mut shadow: Self::Shadow<'_>) -> Result<Self, ::proto_rs::DecodeError> {
+                #(#hooks)*
+                ::proto_rs::ProtoShadow::to_sun(shadow)
+            }
+        }
+    }
+}
+
+fn field_wire_type(field: &FieldInfo<'_>) -> Type {
+    let original_ty = &field.field.ty;
+
+    if let Some(into_ty) = field.config.into_type.as_ref() {
+        let ty: Type = parse_str(into_ty).expect("invalid #[proto(into = ...)] type");
+        if option_inner_type(original_ty).is_some() {
+            parse_quote! { ::core::option::Option<#ty> }
+        } else {
+            ty
+        }
+    } else if let Some(from_ty) = field.config.from_type.as_ref() {
+        let ty: Type = parse_str(from_ty).expect("invalid #[proto(from = ...)] type");
+        if option_inner_type(original_ty).is_some() {
+            parse_quote! { ::core::option::Option<#ty> }
+        } else {
+            ty
+        }
+    } else {
+        original_ty.clone()
+    }
+}
+
+fn encode_value_expr(field: &FieldInfo<'_>, access_expr: TokenStream2) -> TokenStream2 {
+    if field.config.skip {
+        return access_expr;
+    }
+
+    if let Some(into_ty) = field.config.into_type.as_ref().or(field.config.from_type.as_ref()) {
+        let ty_tokens: Type = parse_str(into_ty).expect("invalid #[proto(into)] type");
+        if let Some(fun) = field.config.into_fn.as_ref() {
+            let path: syn::Path = parse_str(fun).expect("invalid #[proto(into_fn)] path");
+            if is_option_type(&field.field.ty) {
+                quote! { (#access_expr).as_ref().map(|__proto_rs_value| #path(__proto_rs_value)) }
+            } else {
+                quote! { #path(&(#access_expr)) }
+            }
+        } else if is_option_type(&field.field.ty) {
+            quote! {
+                (#access_expr)
+                    .as_ref()
+                    .map(|__proto_rs_value| <#ty_tokens as ::core::convert::From<_>>::from(::core::clone::Clone::clone(__proto_rs_value)))
+            }
+        } else {
+            quote! { <#ty_tokens as ::core::convert::From<_>>::from(::core::clone::Clone::clone(&(#access_expr))) }
+        }
+    } else {
+        access_expr
+    }
+}
+
+fn encode_input_expr(wire_ty: &Type, value_expr: TokenStream2) -> TokenStream2 {
+    if is_option_type(wire_ty) {
+        let inner = option_inner_type(wire_ty).expect("option missing inner type");
+        if is_value_encode_type(&inner) {
+            quote! { (#value_expr).as_ref().map(|inner| *inner) }
+        } else {
+            quote! { (#value_expr).as_ref().map(|inner| inner) }
+        }
+    } else if is_value_encode_type(wire_ty) {
+        value_expr
+    } else {
+        quote! { &(#value_expr) }
+    }
+}
+
+fn option_inner_type(ty: &Type) -> Option<Type> {
+    if let Type::Path(path) = ty
+        && let Some(seg) = path.path.segments.last()
+        && seg.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        Some(inner.clone())
+    } else {
+        None
+    }
+}
+
+fn default_expr_for_field(info: &FieldInfo<'_>, ty: &Type) -> TokenStream2 {
+    if needs_manual_handling(info) {
+        if is_option_type(ty) {
+            quote! { None }
+        } else if vec_inner_type(ty).is_some() {
+            quote! { ::proto_rs::alloc::vec::Vec::new() }
+        } else {
+            quote! { ::core::default::Default::default() }
+        }
+    } else {
+        quote! { <#ty as ::proto_rs::ProtoWire>::proto_default() }
+    }
+}
+
+fn needs_manual_handling(info: &FieldInfo<'_>) -> bool {
+    info.config.skip || info.config.into_type.is_some() || info.config.from_type.is_some() || info.config.into_fn.is_some() || info.config.from_fn.is_some()
+}
+
+fn needs_conversion(info: &FieldInfo<'_>) -> bool {
+    info.config.into_type.is_some() || info.config.from_type.is_some() || info.config.into_fn.is_some() || info.config.from_fn.is_some()
+}
+
+fn build_decode_assignment(info: &FieldInfo<'_>, tmp_ident: &Ident, target_access: TokenStream2, wire_ty: &Type) -> TokenStream2 {
+    if let Some(fun) = info.config.from_fn.as_ref() {
+        let path: syn::Path = parse_str(fun).expect("invalid #[proto(from_fn = ...)] path");
+        quote! { #target_access = #path(#tmp_ident); }
+    } else {
+        let field_ty = &info.field.ty;
+        quote! { #target_access = <#field_ty as ::core::convert::From<#wire_ty>>::from(#tmp_ident); }
+    }
 }


### PR DESCRIPTION
## Summary
- respect #[proto(skip)] fields by omitting tag assignment and generating post-decode hooks
- support #[proto(into/...)] conversions when preparing encode inputs and decode assignments
- adjust encode/len helpers to bind values using the field's wire type rather than always borrowing

## Testing
- cargo fmt
- cargo test *(fails: existing proto_message map/set bounds do not support primitive keys/values)*

------
https://chatgpt.com/codex/tasks/task_e_6900ecbc804483218e7c30945668cbe5