### PR TITLE
Improve proto_message macro handling of tuple variants and defaults

### DIFF
--- a/crates/prosto_derive/src/proto_message/enums.rs
+++ b/crates/prosto_derive/src/proto_message/enums.rs
@@ -28,13 +28,6 @@ pub(super) fn generate_simple_enum_impl(input: &DeriveInput, item_enum: &ItemEnu
         Err(err) => return err.to_compile_error(),
     };
 
-    if let Some(idx) = marked_default
-        && discriminants.get(idx).copied() != Some(0)
-    {
-        let variant = &data.variants[idx];
-        return syn::Error::new(variant.span(), "enum #[default] variant must have discriminant 0").to_compile_error();
-    }
-
     let Some(zero_index) = discriminants.iter().position(|&value| value == 0) else {
         return syn::Error::new(data.variants.span(), "proto enums must contain a variant with discriminant 0").to_compile_error();
     };

--- a/crates/prosto_derive/src/proto_message/structs.rs
+++ b/crates/prosto_derive/src/proto_message/structs.rs
@@ -85,7 +85,7 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
     };
 
     let proto_ext_impl = generate_proto_ext_impl(name, &impl_generics, &ty_generics, where_clause, &fields, config);
-    let proto_wire_impl = generate_proto_wire_impl(name, &impl_generics, &ty_generics, where_clause, &fields);
+    let proto_wire_impl = generate_proto_wire_impl(name, &impl_generics, &ty_generics, where_clause, &fields, &data.fields);
 
     quote! {
         #struct_item
@@ -203,8 +203,15 @@ fn generate_proto_ext_impl(
     }
 }
 
-fn generate_proto_wire_impl(name: &syn::Ident, impl_generics: &syn::ImplGenerics, ty_generics: &syn::TypeGenerics, where_clause: Option<&syn::WhereClause>, fields: &[FieldInfo<'_>]) -> TokenStream2 {
-    let proto_default_expr = build_proto_default_expr(fields);
+fn generate_proto_wire_impl(
+    name: &syn::Ident,
+    impl_generics: &syn::ImplGenerics,
+    ty_generics: &syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+    fields: &[FieldInfo<'_>],
+    original_fields: &syn::Fields,
+) -> TokenStream2 {
+    let proto_default_expr = build_proto_default_expr(fields, original_fields);
     let self_tokens = quote! { self };
     let clear_stmts = build_clear_stmts(fields, &self_tokens);
     let encode_input_tokens = quote! { value };


### PR DESCRIPTION
## Summary
- allow complex enum tuple variants to reuse FieldInfo, supporting skip hooks, custom tags, and conversions while fixing decode logic
- relax simple enum #[default] discriminant requirements and sanitize generated enum field attributes
- fix struct proto defaults for empty structs and update encode bindings for direct accesses

## Testing
- cargo check --examples

------
https://chatgpt.com/codex/tasks/task_e_6901002756208321b3a037cd0eab297f