### PR TITLE
Fix protobuf length calculations

### DIFF
--- a/src/wrappers/sets.rs
+++ b/src/wrappers/sets.rs
@@ -117,7 +117,7 @@ where
             }
             ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => {
                 for m in value {
-                    let len = T::encoded_len_impl(&m);
+                    let len = unsafe { T::encoded_len_impl_raw(&m) };
                     encode_key(tag, WireType::LengthDelimited, buf);
                     encode_varint(len as u64, buf);
                     T::encode_raw_unchecked(m, buf);
@@ -300,7 +300,7 @@ mod hashset_impl {
                 }
                 ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => {
                     for m in value {
-                        let len = T::encoded_len_impl(&m);
+                        let len = unsafe { T::encoded_len_impl_raw(&m) };
                         encode_key(tag, WireType::LengthDelimited, buf);
                         encode_varint(len as u64, buf);
                         T::encode_raw_unchecked(m, buf);

--- a/src/wrappers/vecs.rs
+++ b/src/wrappers/vecs.rs
@@ -84,10 +84,7 @@ where
     unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
         match T::KIND {
             // ---- Packed numeric fields -------------------------------------
-            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => value
-                .iter()
-                .map(|value: &T| unsafe { T::encoded_len_impl_raw(&value) })
-                .sum::<usize>(),
+            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => value.iter().map(|value: &T| unsafe { T::encoded_len_impl_raw(&value) }).sum::<usize>(),
 
             // ---- Repeated messages -----------------------------------------
             ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => value
@@ -121,10 +118,7 @@ where
                     return Ok(());
                 }
                 encode_key(tag, WireType::LengthDelimited, buf);
-                let body_len = value
-                    .iter()
-                    .map(|value: &T| unsafe { T::encoded_len_impl_raw(&value) })
-                    .sum::<usize>();
+                let body_len = value.iter().map(|value: &T| unsafe { T::encoded_len_impl_raw(&value) }).sum::<usize>();
                 encode_varint(body_len as u64, buf);
                 for v in value {
                     T::encode_raw_unchecked(v, buf);

--- a/tests/encoding_roundtrip.rs
+++ b/tests/encoding_roundtrip.rs
@@ -379,6 +379,7 @@ where
 {
     let len = <M as ProtoWire>::encoded_len(value);
     let mut buf = BytesMut::with_capacity(len + encoded_len_varint(len as u64));
+    encoding::encode_varint(len as u64, &mut buf);
     <M as ProtoExt>::encode(value, &mut buf).expect("proto length-delimited encode failed");
     buf.freeze()
 }


### PR DESCRIPTION
## Summary
- correct tuple enum variant length logic to account for variant tags
- ensure simple enums declare repr(i32) and default variant discriminants
- fix collection wrappers to compute raw length-delimited sizes and adjust encoding helpers
- update ProtoExt encoding paths and length-delimited test helper

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_6901e6c1199883218435fa0d0985101a