### PR TITLE
Use Solana types as proto suns

### DIFF
--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -93,7 +93,11 @@ pub fn parse_field_type(ty: &Type) -> ParsedFieldType {
 
 /// True if the type is `[u8; N]`.
 pub fn is_bytes_array(ty: &Type) -> bool {
-    matches!(ty, Type::Array(array) if matches!(&*array.elem, Type::Path(inner) if last_ident(inner).is_some_and(|id| id == "u8")))
+    match ty {
+        Type::Array(array) => matches!(&*array.elem, Type::Path(inner) if last_ident(inner).is_some_and(|id| id == "u8")),
+        Type::Path(path) => last_ident(path).is_some_and(|id| id == "FixedBytes"),
+        _ => false,
+    }
 }
 
 /// True if the type is `Vec<u8>` or `Bytes`.


### PR DESCRIPTION
## Summary
- use `solana_address::Address` and `solana_signature::Signature` directly as the sun types for their proto shadows
- update the Solana custom-type tests to exercise the `ProtoExt` implementations on the real Solana types

## Testing
- cargo test --all-features

------
https://chatgpt.com/codex/tasks/task_e_6902236dfb98832181f99588205c666e