### PR TITLE
Update derive macros for generic ProtoShadow support

### DIFF
--- a/crates/prosto_derive/src/proto_message/complex_enums.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enums.rs
@@ -43,11 +43,7 @@ pub(super) fn generate_complex_enum_impl(input: &DeriveInput, item_enum: &ItemEn
     }
     variants[default_index].is_default = true;
 
-    let proto_shadow_impl = if config.has_suns() {
-        quote! {}
-    } else {
-        generate_proto_shadow_impl(name, generics)
-    };
+    let proto_shadow_impl = generate_proto_shadow_impl(name, generics);
 
     let shadow_ty = quote! { #name #ty_generics };
 

--- a/crates/prosto_derive/src/proto_message/enums.rs
+++ b/crates/prosto_derive/src/proto_message/enums.rs
@@ -66,11 +66,7 @@ pub(super) fn generate_simple_enum_impl(input: &DeriveInput, item_enum: &ItemEnu
         })
         .collect();
 
-    let proto_shadow_impl = if config.has_suns() {
-        quote! {}
-    } else {
-        generate_proto_shadow_impl(name, generics)
-    };
+    let proto_shadow_impl = generate_proto_shadow_impl(name, generics);
 
     let shadow_ty = quote! { #name #ty_generics };
 

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -164,7 +164,7 @@ pub fn assign_tags(mut fields: Vec<FieldInfo<'_>>) -> Vec<FieldInfo<'_>> {
 pub fn generate_proto_shadow_impl(name: &Ident, generics: &syn::Generics) -> TokenStream2 {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     quote! {
-        impl #impl_generics ::proto_rs::ProtoShadow for #name #ty_generics #where_clause {
+        impl #impl_generics ::proto_rs::ProtoShadow<Self> for #name #ty_generics #where_clause {
             type Sun<'a> = &'a Self;
             type OwnedSun = Self;
             type View<'a> = &'a Self;

--- a/src/custom_types/fastnum/unsigned.rs
+++ b/src/custom_types/fastnum/unsigned.rs
@@ -64,7 +64,7 @@ mod tests {
     }
 
     fn decode(proto: UD128Proto) -> UD128 {
-        ProtoShadow::to_sun(proto).unwrap()
+        ProtoShadow::<UD128>::to_sun(proto).unwrap()
     }
 
     #[test]

--- a/tests/encoding_roundtrip.rs
+++ b/tests/encoding_roundtrip.rs
@@ -356,7 +356,7 @@ fn assert_decode_roundtrip(bytes: Bytes, proto_expected: &SampleMessage, prost_e
 fn encode_proto_message<M>(value: &M) -> Bytes
 where
     for<'a> M: ProtoExt + ProtoWire<EncodeInput<'a> = &'a M>,
-    for<'a> Shadow<'a, M>: ProtoShadow<Sun<'a> = &'a M, View<'a> = &'a M>,
+    for<'a> Shadow<'a, M>: ProtoShadow<M, Sun<'a> = &'a M, View<'a> = &'a M>,
 {
     let len = <M as ProtoWire>::encoded_len(value);
     let mut buf = BytesMut::with_capacity(len);
@@ -373,7 +373,7 @@ fn encode_prost_message<M: ProstMessage>(value: &M) -> Bytes {
 fn encode_proto_length_delimited<M>(value: &M) -> Bytes
 where
     for<'a> M: ProtoExt + ProtoWire<EncodeInput<'a> = &'a M>,
-    for<'a> Shadow<'a, M>: ProtoShadow<Sun<'a> = &'a M, View<'a> = &'a M>,
+    for<'a> Shadow<'a, M>: ProtoShadow<M, Sun<'a> = &'a M, View<'a> = &'a M>,
 {
     let len = <M as ProtoWire>::encoded_len(value);
     let mut buf = BytesMut::with_capacity(len + encoded_len_varint(len as u64));
@@ -647,9 +647,7 @@ fn map_default_entries_align_with_prost() {
     let proto_bytes = CollectionsMessage::encode_to_vec(&message);
 
     let mut prost_bytes = Vec::new();
-    CollectionsMessageProst::from(&message)
-        .encode(&mut prost_bytes)
-        .expect("prost encode default map entries");
+    CollectionsMessageProst::from(&message).encode(&mut prost_bytes).expect("prost encode default map entries");
 
     assert_eq!(proto_bytes, prost_bytes, "map encoding must match prost when default keys or values are present");
 


### PR DESCRIPTION
## Summary
- always emit `ProtoShadow<Self>` impls from the derive macros so shadows remain usable alongside custom suns
- teach the generated `ProtoWire` implementations to pick the correct view type under the new generic parameter and update affected call sites
- fix remaining ambiguous `ProtoShadow` usages in tests/examples now that the trait is generic

## Testing
- cargo test --all-features

------
https://chatgpt.com/codex/tasks/task_e_6902521ae1cc8321a406f851abbde58d