### PR TITLE
Fix complex enum merge assignment and skip field patterns

### DIFF
--- a/crates/prosto_derive/src/proto_message/complex_enums.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enums.rs
@@ -387,7 +387,11 @@ fn build_variant_encoded_len_arm(variant: &VariantInfo<'_>) -> TokenStream2 {
             } else {
                 let bindings = fields.iter().map(|info| {
                     let field_ident = info.field.ident.as_ref().expect("named field");
-                    quote! { #field_ident: ref #field_ident }
+                    if info.config.skip {
+                        quote! { #field_ident: _ }
+                    } else {
+                        quote! { #field_ident: ref #field_ident }
+                    }
                 });
                 let terms = build_encoded_len_terms(fields, &TokenStream2::new());
                 quote! {
@@ -463,7 +467,11 @@ fn build_variant_encode_arm(variant: &VariantInfo<'_>) -> TokenStream2 {
             } else {
                 let bindings = fields.iter().map(|info| {
                     let field_ident = info.field.ident.as_ref().expect("named field");
-                    quote! { #field_ident: ref #field_ident }
+                    if info.config.skip {
+                        quote! { #field_ident: _ }
+                    } else {
+                        quote! { #field_ident: ref #field_ident }
+                    }
                 });
                 let terms = build_encoded_len_terms(fields, &TokenStream2::new());
                 let encode_stmts = build_encode_stmts(fields, &TokenStream2::new());
@@ -548,8 +556,8 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
                     let skip_binding_ident = Ident::new(&format!("__proto_rs_variant_{}_skip_binding", ident.to_string().to_lowercase()), field.field.field.span());
                     let computed_ident = Ident::new(&format!("__proto_rs_variant_{}_computed", ident.to_string().to_lowercase()), field.field.field.span());
                     quote! {
-                        let #computed_ident = #fun_path(&variant_value);
-                        if let #name::#ident(ref mut #skip_binding_ident) = variant_value {
+                        let #computed_ident = #fun_path(&*value);
+                        if let #name::#ident(ref mut #skip_binding_ident) = value {
                             *#skip_binding_ident = #computed_ident;
                         }
                     }
@@ -564,9 +572,8 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
                 #tag => {
                     let mut #binding_ident = #binding_default;
                     #decode_stmt
-                    let mut variant_value = #name::#ident(#binding_ident);
+                    *value = #name::#ident(#binding_ident);
                     #post_hook
-                    *value = variant_value;
                     Ok(())
                 }
             }
@@ -635,21 +642,16 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
                     let skip_binding_ident = Ident::new(&format!("__proto_rs_variant_{}_{}_skip_binding", ident.to_string().to_lowercase(), info.index), info.field.span());
                     let computed_ident = Ident::new(&format!("__proto_rs_variant_{}_{}_computed", ident.to_string().to_lowercase(), info.index), info.field.span());
                     Some(quote! {
-                        let #computed_ident = #fun_path(&variant_value);
-                        if let #name::#ident { #field_ident: ref mut #skip_binding_ident, .. } = variant_value {
+                        let #computed_ident = #fun_path(&*value);
+                        if let #name::#ident { #field_ident: ref mut #skip_binding_ident, .. } = value {
                             *#skip_binding_ident = #computed_ident;
                         }
                     })
                 })
                 .collect::<Vec<_>>();
-            let assign_variant = if post_hooks.is_empty() {
-                quote! { *value = #construct_expr; }
-            } else {
-                quote! {
-                    let mut variant_value = #construct_expr;
-                    #(#post_hooks)*
-                    *value = variant_value;
-                }
+            let assign_variant = quote! {
+                *value = #construct_expr;
+                #(#post_hooks)*
             };
             let decode_loop = if decode_match.is_empty() {
                 quote! {


### PR DESCRIPTION
## Summary
- assign complex enum merge results directly without creating temporary variant bindings
- run skip deserialization hooks against the in-place enum value during decoding
- use `_` pattern bindings for skipped fields to avoid unused variable warnings in generated code

## Testing
- cargo test -p prosto_derive *(fails: utils::string_helpers::tests::test_to_snake_case, utils::string_helpers::tests::test_to_upper_snake_case)*

------
https://chatgpt.com/codex/tasks/task_e_6902585f38a88321bb9fd066cfd736c9