### PR TITLE
Adjust complex enum codegen assignments and skip bindings

### DIFF
--- a/crates/prosto_derive/src/proto_message/complex_enums.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enums.rs
@@ -387,7 +387,11 @@ fn build_variant_encoded_len_arm(variant: &VariantInfo<'_>) -> TokenStream2 {
             } else {
                 let bindings = fields.iter().map(|info| {
                     let field_ident = info.field.ident.as_ref().expect("named field");
-                    quote! { #field_ident: ref #field_ident }
+                    if info.config.skip {
+                        quote! { #field_ident: _ }
+                    } else {
+                        quote! { #field_ident: ref #field_ident }
+                    }
                 });
                 let terms = build_encoded_len_terms(fields, &TokenStream2::new());
                 quote! {
@@ -543,30 +547,35 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
             };
 
             let post_hook = if field.field.config.skip {
-                if let Some(fun) = &field.field.config.skip_deser_fn {
+                field.field.config.skip_deser_fn.as_ref().map(|fun| {
                     let fun_path = parse_path_string(field.field.field, fun);
                     let skip_binding_ident = Ident::new(&format!("__proto_rs_variant_{}_skip_binding", ident.to_string().to_lowercase()), field.field.field.span());
                     let computed_ident = Ident::new(&format!("__proto_rs_variant_{}_computed", ident.to_string().to_lowercase()), field.field.field.span());
                     quote! {
-                        let #computed_ident = #fun_path(&variant_value);
-                        if let #name::#ident(ref mut #skip_binding_ident) = variant_value {
+                        let #computed_ident = #fun_path(value);
+                        if let #name::#ident(ref mut #skip_binding_ident) = value {
                             *#skip_binding_ident = #computed_ident;
                         }
                     }
-                } else {
-                    quote! {}
+                })
+            } else {
+                None
+            };
+
+            let assign_variant = if let Some(post_hook) = post_hook {
+                quote! {
+                    *value = #name::#ident(#binding_ident);
+                    #post_hook
                 }
             } else {
-                quote! {}
+                quote! { *value = #name::#ident(#binding_ident); }
             };
 
             quote! {
                 #tag => {
                     let mut #binding_ident = #binding_default;
                     #decode_stmt
-                    let mut variant_value = #name::#ident(#binding_ident);
-                    #post_hook
-                    *value = variant_value;
+                    #assign_variant
                     Ok(())
                 }
             }
@@ -635,8 +644,8 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
                     let skip_binding_ident = Ident::new(&format!("__proto_rs_variant_{}_{}_skip_binding", ident.to_string().to_lowercase(), info.index), info.field.span());
                     let computed_ident = Ident::new(&format!("__proto_rs_variant_{}_{}_computed", ident.to_string().to_lowercase(), info.index), info.field.span());
                     Some(quote! {
-                        let #computed_ident = #fun_path(&variant_value);
-                        if let #name::#ident { #field_ident: ref mut #skip_binding_ident, .. } = variant_value {
+                        let #computed_ident = #fun_path(value);
+                        if let #name::#ident { #field_ident: ref mut #skip_binding_ident, .. } = value {
                             *#skip_binding_ident = #computed_ident;
                         }
                     })
@@ -646,9 +655,8 @@ fn build_variant_merge_arm(name: &Ident, variant: &VariantInfo<'_>) -> TokenStre
                 quote! { *value = #construct_expr; }
             } else {
                 quote! {
-                    let mut variant_value = #construct_expr;
+                    *value = #construct_expr;
                     #(#post_hooks)*
-                    *value = variant_value;
                 }
             };
             let decode_loop = if decode_match.is_empty() {


### PR DESCRIPTION
## Summary
- update complex enum merge_field codegen to assign directly to the output value and run skip hooks on the value itself
- apply `_` patterns for skipped struct fields during encoding to silence unused binding warnings

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6902585f38a88321bb9fd066cfd736c9