### PR TITLE
Fix transparent wrapper decoding for message types

### DIFF
--- a/crates/prosto_derive/src/proto_message/structs.rs
+++ b/crates/prosto_derive/src/proto_message/structs.rs
@@ -28,7 +28,7 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
 
     let struct_item = sanitize_struct(item_struct.clone());
 
-    let fields = match &data.fields {
+    let mut fields = match &data.fields {
         syn::Fields::Named(named) => named
             .named
             .iter()
@@ -74,6 +74,22 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
         syn::Fields::Unit => Vec::new(),
     };
 
+    if let Some(idx) = fields.iter().position(|info| info.config.is_transparent) {
+        if fields.len() != 1 {
+            panic!("#[proto(trasparent)] requires a single-field struct");
+        }
+
+        let field = fields.remove(idx);
+        let proto_shadow_impl = generate_proto_shadow_impl(name, generics);
+        let transparent_impl = generate_transparent_struct_impl(name, &impl_generics, &ty_generics, where_clause, &field, &data.fields);
+
+        return quote! {
+            #struct_item
+            #proto_shadow_impl
+            #transparent_impl
+        };
+    }
+
     let fields = assign_tags(fields);
 
     let proto_shadow_impl = generate_proto_shadow_impl(name, generics);
@@ -86,6 +102,182 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
         #proto_shadow_impl
         #proto_ext_impl
         #proto_wire_impl
+    }
+}
+
+fn generate_transparent_struct_impl(
+    name: &syn::Ident,
+    impl_generics: &syn::ImplGenerics,
+    ty_generics: &syn::TypeGenerics,
+    where_clause: Option<&syn::WhereClause>,
+    field: &FieldInfo<'_>,
+    original_fields: &syn::Fields,
+) -> TokenStream2 {
+    let inner_ty = &field.field.ty;
+    let mut_value_access = field.access.access_tokens(quote! { value });
+    let mut_self_access = field.access.access_tokens(quote! { self });
+
+    let wrap_expr = match original_fields {
+        syn::Fields::Unnamed(_) => quote! { Self(inner) },
+        syn::Fields::Named(_) => {
+            let ident = field.access.ident().expect("expected named field ident for transparent struct");
+            quote! { Self { #ident: inner } }
+        }
+        syn::Fields::Unit => quote! { Self },
+    };
+
+    let default_expr = match original_fields {
+        syn::Fields::Unnamed(_) => quote! { Self(<#inner_ty as ::proto_rs::ProtoWire>::proto_default()) },
+        syn::Fields::Named(_) => {
+            let ident = field.access.ident().expect("expected named field ident for transparent struct");
+            quote! { Self { #ident: <#inner_ty as ::proto_rs::ProtoWire>::proto_default() } }
+        }
+        syn::Fields::Unit => quote! { Self },
+    };
+
+    let is_default_binding = super::unified_field_handler::encode_input_binding(field, &quote! { value });
+    let is_default_prelude: Vec<_> = is_default_binding.prelude.into_iter().collect();
+    let is_default_value = is_default_binding.value;
+
+    let encoded_len_binding = super::unified_field_handler::encode_input_binding(field, &quote! { value });
+    let encoded_len_prelude: Vec<_> = encoded_len_binding.prelude.into_iter().collect();
+    let encoded_len_value = encoded_len_binding.value;
+
+    let encode_raw_binding = super::unified_field_handler::encode_input_binding(field, &quote! { value });
+    let encode_raw_prelude: Vec<_> = encode_raw_binding.prelude.into_iter().collect();
+    let encode_raw_value = encode_raw_binding.value;
+
+    quote! {
+        impl #impl_generics ::proto_rs::ProtoExt for #name #ty_generics #where_clause {
+            type Shadow<'b> = #name #ty_generics where Self: 'b;
+
+            #[inline(always)]
+            fn merge_field(
+                _value: &mut Self::Shadow<'_>,
+                tag: u32,
+                wire_type: ::proto_rs::encoding::WireType,
+                buf: &mut impl ::proto_rs::bytes::Buf,
+                ctx: ::proto_rs::encoding::DecodeContext,
+            ) -> Result<(), ::proto_rs::DecodeError> {
+                ::proto_rs::encoding::skip_field(wire_type, tag, buf, ctx)
+            }
+
+            #[inline(always)]
+            fn decode(mut buf: impl ::proto_rs::bytes::Buf) -> Result<Self, ::proto_rs::DecodeError> {
+                if ::core::matches!(
+                    <#inner_ty as ::proto_rs::ProtoWire>::KIND,
+                    ::proto_rs::ProtoKind::Message
+                ) {
+                    let inner = <#inner_ty as ::proto_rs::ProtoExt>::decode(buf)?;
+                    Ok(#wrap_expr)
+                } else {
+                    let mut inner = <#inner_ty as ::proto_rs::ProtoWire>::proto_default();
+                    <#inner_ty as ::proto_rs::ProtoWire>::decode_into(
+                        <#inner_ty as ::proto_rs::ProtoWire>::WIRE_TYPE,
+                        &mut inner,
+                        &mut buf,
+                        ::proto_rs::encoding::DecodeContext::default(),
+                    )?;
+                    Ok(#wrap_expr)
+                }
+            }
+
+            #[inline(always)]
+            fn decode_length_delimited(
+                mut buf: impl ::proto_rs::bytes::Buf,
+                ctx: ::proto_rs::encoding::DecodeContext,
+            ) -> Result<Self, ::proto_rs::DecodeError> {
+                if ::core::matches!(
+                    <#inner_ty as ::proto_rs::ProtoWire>::KIND,
+                    ::proto_rs::ProtoKind::Message
+                ) {
+                    let inner = <#inner_ty as ::proto_rs::ProtoExt>::decode_length_delimited(buf, ctx)?;
+                    Ok(#wrap_expr)
+                } else {
+                    let mut inner = <#inner_ty as ::proto_rs::ProtoWire>::proto_default();
+                    <#inner_ty as ::proto_rs::ProtoWire>::decode_into(
+                        <#inner_ty as ::proto_rs::ProtoWire>::WIRE_TYPE,
+                        &mut inner,
+                        &mut buf,
+                        ctx,
+                    )?;
+                    Ok(#wrap_expr)
+                }
+            }
+
+            #[inline(always)]
+            fn merge_length_delimited<B: ::proto_rs::bytes::Buf>(
+                value: &mut Self::Shadow<'_>,
+                buf: &mut B,
+                ctx: ::proto_rs::encoding::DecodeContext,
+            ) -> Result<(), ::proto_rs::DecodeError> {
+                if ::core::matches!(
+                    <#inner_ty as ::proto_rs::ProtoWire>::KIND,
+                    ::proto_rs::ProtoKind::Message
+                ) {
+                    <#inner_ty as ::proto_rs::ProtoExt>::merge_length_delimited(
+                        &mut #mut_value_access,
+                        buf,
+                        ctx,
+                    )
+                } else {
+                    <#inner_ty as ::proto_rs::ProtoWire>::decode_into(
+                        <#inner_ty as ::proto_rs::ProtoWire>::WIRE_TYPE,
+                        &mut #mut_value_access,
+                        buf,
+                        ctx,
+                    )
+                }
+            }
+        }
+
+        impl #impl_generics ::proto_rs::ProtoWire for #name #ty_generics #where_clause {
+            type EncodeInput<'b> = &'b Self;
+            const KIND: ::proto_rs::ProtoKind = <#inner_ty as ::proto_rs::ProtoWire>::KIND;
+
+            #[inline(always)]
+            fn proto_default() -> Self {
+                #default_expr
+            }
+
+            #[inline(always)]
+            fn clear(&mut self) {
+                <#inner_ty as ::proto_rs::ProtoWire>::clear(&mut #mut_self_access);
+            }
+
+            #[inline(always)]
+            fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                #( #is_default_prelude )*
+                <#inner_ty as ::proto_rs::ProtoWire>::is_default_impl(&#is_default_value)
+            }
+
+            #[inline(always)]
+            unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                #( #encoded_len_prelude )*
+                <#inner_ty as ::proto_rs::ProtoWire>::encoded_len_impl_raw(&#encoded_len_value)
+            }
+
+            #[inline(always)]
+            fn encode_raw_unchecked(value: Self::EncodeInput<'_>, buf: &mut impl ::proto_rs::bytes::BufMut) {
+                #( #encode_raw_prelude )*
+                <#inner_ty as ::proto_rs::ProtoWire>::encode_raw_unchecked(#encode_raw_value, buf);
+            }
+
+            #[inline(always)]
+            fn decode_into(
+                wire_type: ::proto_rs::encoding::WireType,
+                value: &mut Self,
+                buf: &mut impl ::proto_rs::bytes::Buf,
+                ctx: ::proto_rs::encoding::DecodeContext,
+            ) -> Result<(), ::proto_rs::DecodeError> {
+                <#inner_ty as ::proto_rs::ProtoWire>::decode_into(
+                    wire_type,
+                    &mut #mut_value_access,
+                    buf,
+                    ctx,
+                )
+            }
+        }
     }
 }
 

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -236,7 +236,7 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
     }
 }
 
-fn is_value_encode_type(ty: &Type) -> bool {
+pub fn is_value_encode_type(ty: &Type) -> bool {
     matches!(ty, Type::Path(type_path)
     if type_path.qself.is_none()
         && type_path.path.segments.len() == 1

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -57,6 +57,7 @@ pub struct FieldConfig {
     pub is_proto_enum: bool,           // prost-like enum (i32 backing)
     pub import_path: Option<String>,
     pub custom_tag: Option<usize>,
+    pub is_transparent: bool,
 }
 
 pub fn parse_field_config(field: &Field) -> FieldConfig {
@@ -90,6 +91,7 @@ pub fn parse_field_config(field: &Field) -> FieldConfig {
                 Some("try_from_fn") => cfg.try_from_fn = parse_string_value(&meta),
                 Some("import_path") => cfg.import_path = parse_string_value(&meta),
                 Some("tag") => cfg.custom_tag = parse_usize_value(&meta),
+                Some("trasparent") | Some("transparent") => cfg.is_transparent = true,
                 _ => {}
             }
             Ok(())

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -1,0 +1,95 @@
+use proto_rs::ProtoExt;
+use proto_rs::ProtoWire;
+use proto_rs::encoding::DecodeContext;
+use proto_rs::encoding::WireType;
+use proto_rs::proto_message;
+
+#[proto_message]
+#[derive(Debug, PartialEq, Eq)]
+pub struct UserIdTuple(#[proto(trasparent)] u64);
+
+#[proto_message]
+#[derive(Debug, PartialEq, Eq)]
+pub struct UserIdNamed {
+    #[proto(trasparent)]
+    pub id: u64,
+}
+
+#[proto_message]
+#[derive(Debug, PartialEq, Eq)]
+pub struct Holder {
+    #[proto(tag = 1)]
+    pub tuple: UserIdTuple,
+    #[proto(tag = 2)]
+    pub named: UserIdNamed,
+}
+
+#[proto_message]
+#[derive(Debug, PartialEq, Eq)]
+pub struct InnerMessage {
+    #[proto(tag = 1)]
+    pub value: u32,
+}
+
+#[proto_message]
+#[derive(Debug, PartialEq, Eq)]
+pub struct MessageWrapper(#[proto(trasparent)] InnerMessage);
+
+#[test]
+fn transparent_tuple_roundtrip() {
+    let original = UserIdTuple(123);
+    let mut buf = Vec::new();
+    <UserIdTuple as ProtoWire>::encode_raw_unchecked(&original, &mut buf);
+    assert_eq!(buf, vec![123]);
+
+    let mut decoded = UserIdTuple::proto_default();
+    <UserIdTuple as ProtoWire>::decode_into(WireType::Varint, &mut decoded, &mut &buf[..], DecodeContext::default()).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn transparent_named_roundtrip() {
+    let original = UserIdNamed { id: 77 };
+    let mut buf = Vec::new();
+    <UserIdNamed as ProtoWire>::encode_raw_unchecked(&original, &mut buf);
+    assert_eq!(buf, vec![77]);
+
+    let mut decoded = UserIdNamed::proto_default();
+    <UserIdNamed as ProtoWire>::decode_into(WireType::Varint, &mut decoded, &mut &buf[..], DecodeContext::default()).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn transparent_in_holder_encodes_inner_once() {
+    let holder = Holder {
+        tuple: UserIdTuple(5),
+        named: UserIdNamed { id: 9 },
+    };
+
+    let mut buf = Vec::new();
+    <Holder as ProtoWire>::encode_raw_unchecked(&holder, &mut buf);
+
+    // Expected encoding:
+    // field 1 (tuple): key 0x08 followed by value 0x05
+    // field 2 (named): key 0x10 followed by value 0x09
+    assert_eq!(buf, vec![0x08, 0x05, 0x10, 0x09]);
+}
+
+#[test]
+fn transparent_message_roundtrip_top_level() {
+    let original = MessageWrapper(InnerMessage { value: 42 });
+    let buf = <MessageWrapper as ProtoExt>::encode_to_vec(&original);
+    let decoded = <MessageWrapper as ProtoExt>::decode(&buf[..]).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn transparent_message_decode_length_delimited_body() {
+    let body = vec![0x02, 0x08, 0x2A];
+    let decoded = <MessageWrapper as ProtoExt>::decode_length_delimited(
+        &body[..],
+        DecodeContext::default(),
+    )
+    .unwrap();
+    assert_eq!(decoded, MessageWrapper(InnerMessage { value: 42 }));
+}


### PR DESCRIPTION
## Summary
- branch the transparent wrapper decode/merge logic to call `ProtoExt` for message kinds
- reuse `encode_input_binding` so transparent wrappers encode and size inner values with the proper borrowing semantics
- cover transparent wrappers around messages with top-level and length-delimited regression tests

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913d3ba729c8321be5688e4de26a373)