### PR TITLE
Handle CachePadded wrappers when emitting proto schemas

### DIFF
--- a/crates/prosto_derive/src/emit_proto.rs
+++ b/crates/prosto_derive/src/emit_proto.rs
@@ -11,6 +11,7 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 
 use crate::utils::MethodInfo;
+use crate::utils::cache_padded_inner_type;
 use crate::utils::collect_discriminants_for_variants;
 use crate::utils::find_marked_default_variant;
 use crate::utils::is_bytes_array;
@@ -233,6 +234,8 @@ fn extract_field_wrapper_info(ty: &Type) -> (bool, bool, Type) {
         (false, true, inner)
     } else if let Some((inner, _)) = set_inner_type(ty) {
         (false, true, inner)
+    } else if let Some(inner) = cache_padded_inner_type(ty) {
+        (false, false, inner)
     } else if let Type::Array(_) = ty {
         if is_bytes_array(ty) {
             // Preserve array type for bytes

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -42,6 +42,19 @@ pub fn set_inner_type(ty: &Type) -> Option<(Type, SetKind)> {
     None
 }
 
+pub fn cache_padded_inner_type(ty: &Type) -> Option<Type> {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && segment.ident == "CachePadded"
+        && let PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner.clone());
+    }
+
+    None
+}
+
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct FieldConfig {

--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -147,7 +147,7 @@ fn parse_path_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
             "HashMap" => return parse_map_type(path, ty, MapKind::HashMap),
             "BTreeMap" => return parse_map_type(path, ty, MapKind::BTreeMap),
             "HashSet" | "BTreeSet" => return parse_set_type(path, ty),
-            "Box" | "Arc" => return parse_box_like_type(path, ty),
+            "Box" | "Arc" | "CachePadded" => return parse_box_like_type(path, ty),
             "ZeroCopy" => return parse_zero_copy_type(path, ty),
             _ => {}
         }


### PR DESCRIPTION
## Summary
- treat crossbeam_utils::CachePadded as a transparent wrapper when emitting proto schema fields
- add a helper for retrieving the CachePadded inner type for schema utilities
- reuse the existing box-like parsing path so type analysis maps CachePadded to its inner type

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e48f3ce08321808aee6f2b2e94e9)