### PR TITLE
Fix ArcSwap schema modifiers in proto generation

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -251,7 +251,7 @@ fn extract_field_type_name(ty: &syn::Type) -> String {
     {
         let ident = &segment.ident;
 
-        if matches!(ident.to_string().as_str(), "Option" | "Vec")
+        if (ident == "Option" || ident == "Vec" || ident == "ArcSwap" || ident == "ArcSwapOption")
             && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
             && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
         {
@@ -315,6 +315,12 @@ mod tests {
         assert_eq!(extract_field_type_name(&ty), "MyType");
 
         let ty: syn::Type = parse_quote! { Vec<MyType> };
+        assert_eq!(extract_field_type_name(&ty), "MyType");
+
+        let ty: syn::Type = parse_quote! { arc_swap::ArcSwap<MyType> };
+        assert_eq!(extract_field_type_name(&ty), "MyType");
+
+        let ty: syn::Type = parse_quote! { arc_swap::ArcSwapOption<MyType> };
         assert_eq!(extract_field_type_name(&ty), "MyType");
     }
 

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -55,6 +55,19 @@ pub fn cache_padded_inner_type(ty: &Type) -> Option<Type> {
     None
 }
 
+pub fn arc_swap_inner_type(ty: &Type) -> Option<Type> {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && segment.ident == "ArcSwap"
+        && let PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner.clone());
+    }
+
+    None
+}
+
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct FieldConfig {
@@ -151,6 +164,10 @@ pub fn rust_type_path_ident(ty: &Type) -> syn::Ident {
 
 pub fn is_option_type(ty: &Type) -> bool {
     matches!(last_path_segment(ty), Some(seg) if seg.ident == "Option")
+}
+
+pub fn is_arc_swap_option_type(ty: &Type) -> bool {
+    matches!(last_path_segment(ty), Some(seg) if seg.ident == "ArcSwapOption")
 }
 
 pub fn vec_inner_type(ty: &Type) -> Option<Type> {

--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -143,11 +143,12 @@ fn parse_path_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
     if let Some(id) = last_ident(path) {
         match id.to_string().as_str() {
             "Option" => return parse_option_type(path, ty),
+            "ArcSwapOption" => return parse_arc_swap_option_type(path, ty),
             "Vec" => return parse_vec_type(path, ty),
             "HashMap" => return parse_map_type(path, ty, MapKind::HashMap),
             "BTreeMap" => return parse_map_type(path, ty, MapKind::BTreeMap),
             "HashSet" | "BTreeSet" => return parse_set_type(path, ty),
-            "Box" | "Arc" | "CachePadded" => return parse_box_like_type(path, ty),
+            "ArcSwap" | "Box" | "Arc" | "CachePadded" => return parse_box_like_type(path, ty),
             "ZeroCopy" => return parse_zero_copy_type(path, ty),
             _ => {}
         }
@@ -158,6 +159,17 @@ fn parse_path_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
 fn parse_option_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
     let Some(inner_ty) = single_generic(path) else {
         panic!("Option must have a single generic argument");
+    };
+    let mut inner = parse_field_type(inner_ty);
+    inner.is_option = true;
+    inner.rust_type = ty.clone();
+    inner.elem_type = (*inner_ty).clone();
+    inner
+}
+
+fn parse_arc_swap_option_type(path: &TypePath, ty: &Type) -> ParsedFieldType {
+    let Some(inner_ty) = single_generic(path) else {
+        panic!("ArcSwapOption must have a single generic argument");
     };
     let mut inner = parse_field_type(inner_ty);
     inner.is_option = true;

--- a/protos/tests/arc_swap.proto
+++ b/protos/tests/arc_swap.proto
@@ -3,11 +3,22 @@ syntax = "proto3";
 package arc_swap;
 
 message OptionalSwapHolder {
-  ArcSwapOption maybe = 1;
+  optional SwapInner maybe = 1;
 }
 
 message SwapHolder {
-  ArcSwap primary = 1;
+  SwapInner primary = 1;
+}
+
+message ArcSwapContainerHolder {
+  bytes swap_bytes = 1;
+  repeated uint64 swap_u64s = 2;
+  repeated uint64 swap_array_u64 = 3;
+  bytes swap_array_bytes = 4;
+}
+
+message ArcSwapOptionBytesHolder {
+  optional bytes maybe_swap_bytes = 1;
 }
 
 message SwapInner {

--- a/tests/arc_swap_roundtrip.rs
+++ b/tests/arc_swap_roundtrip.rs
@@ -44,6 +44,45 @@ impl Default for OptionalSwapHolder {
     }
 }
 
+#[proto_message(proto_path = "protos/tests/arc_swap.proto")]
+#[derive(Debug)]
+pub struct ArcSwapContainerHolder {
+    #[proto(tag = 1)]
+    pub swap_bytes: ArcSwap<Vec<u8>>,
+    #[proto(tag = 2)]
+    pub swap_u64s: ArcSwap<Vec<u64>>,
+    #[proto(tag = 3)]
+    pub swap_array_u64: ArcSwap<[u64; 32]>,
+    #[proto(tag = 4)]
+    pub swap_array_bytes: ArcSwap<[u8; 32]>,
+}
+
+impl Default for ArcSwapContainerHolder {
+    fn default() -> Self {
+        Self {
+            swap_bytes: ArcSwap::from_pointee(Vec::new()),
+            swap_u64s: ArcSwap::from_pointee(Vec::new()),
+            swap_array_u64: ArcSwap::from_pointee([0_u64; 32]),
+            swap_array_bytes: ArcSwap::from_pointee([0_u8; 32]),
+        }
+    }
+}
+
+#[proto_message(proto_path = "protos/tests/arc_swap.proto")]
+#[derive(Debug)]
+pub struct ArcSwapOptionBytesHolder {
+    #[proto(tag = 1)]
+    pub maybe_swap_bytes: ArcSwapOption<Vec<u8>>,
+}
+
+impl Default for ArcSwapOptionBytesHolder {
+    fn default() -> Self {
+        Self {
+            maybe_swap_bytes: ArcSwapOption::new(None),
+        }
+    }
+}
+
 #[test]
 fn arc_swap_roundtrip_preserves_inner_value() {
     let holder = SwapHolder {
@@ -82,4 +121,37 @@ fn arc_swap_option_roundtrip_handles_absent_value() {
 
     let guard = decoded.maybe.load();
     assert!(guard.as_ref().is_none());
+}
+
+#[test]
+fn arc_swap_vec_u8_roundtrip_encodes_as_bytes() {
+    let holder = ArcSwapContainerHolder {
+        swap_bytes: ArcSwap::from_pointee(vec![5, 8, 13, 21]),
+        ..ArcSwapContainerHolder::default()
+    };
+
+    let encoded = <ArcSwapContainerHolder as ProtoExt>::encode_to_vec(&holder);
+    let decoded = <ArcSwapContainerHolder as ProtoExt>::decode(&encoded[..]).expect("decode arc swap container holder bytes");
+
+    let bytes_guard = decoded.swap_bytes.load();
+    assert_eq!(bytes_guard.as_slice(), &[5, 8, 13, 21]);
+}
+
+#[test]
+fn arc_swap_option_bytes_roundtrip_handles_presence_and_absence() {
+    let holder = ArcSwapOptionBytesHolder {
+        maybe_swap_bytes: ArcSwapOption::new(Some(Arc::new(vec![1, 2, 3, 4]))),
+    };
+
+    let encoded = <ArcSwapOptionBytesHolder as ProtoExt>::encode_to_vec(&holder);
+    let decoded = <ArcSwapOptionBytesHolder as ProtoExt>::decode(&encoded[..]).expect("decode arc swap option bytes");
+
+    let present_guard = decoded.maybe_swap_bytes.load();
+    let bytes = present_guard.as_ref().expect("expected bytes");
+    assert_eq!(bytes.as_slice(), &[1, 2, 3, 4]);
+
+    let default_holder = ArcSwapOptionBytesHolder::default();
+    let encoded_default = <ArcSwapOptionBytesHolder as ProtoExt>::encode_to_vec(&default_holder);
+    let decoded_default = <ArcSwapOptionBytesHolder as ProtoExt>::decode(&encoded_default[..]).expect("decode default arc swap option bytes");
+    assert!(decoded_default.maybe_swap_bytes.load().as_ref().is_none());
 }


### PR DESCRIPTION
## Summary
- treat `ArcSwapOption` as an option-like wrapper when extracting field modifiers for proto emission
- recurse through `ArcSwap<T>` during wrapper analysis so repeated modifiers from inner collections are preserved
- extend helper utilities and unit tests to cover ArcSwap wrappers and import extraction scenarios

## Testing
- `cargo test --features arc_swap arc_swap_roundtrip`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151889e36483218c36ec99f8102de7)