### PR TITLE
Add rename support to proto generator schema

### DIFF
--- a/tests/rpc_integration.rs
+++ b/tests/rpc_integration.rs
@@ -97,7 +97,7 @@ fn sample_to_tonic(msg: &SampleMessage) -> tonic_prost_test::encoding::SampleMes
         id: prost.id,
         flag: prost.flag,
         name: prost.name,
-        data: prost.data.into_iter().map(u32::from).collect(),
+        data: prost.data,
         nested: prost.nested.map(|nested| nested_to_tonic(&nested)),
         nested_list: prost.nested_list.into_iter().map(|nested| nested_to_tonic(&nested)).collect(),
         values: prost.values,
@@ -119,7 +119,7 @@ fn sample_from_tonic(msg: tonic_prost_test::encoding::SampleMessage) -> SampleMe
         optional_mode,
     } = msg;
 
-    let data = data.into_iter().map(|value| u8::try_from(value).expect("value must fit in u8")).collect();
+    let data = data;
 
     let nested = nested.map(nested_from_tonic);
     let nested_list = nested_list.into_iter().map(nested_from_tonic).collect();


### PR DESCRIPTION
## Summary
- add a ProtoRename config to handle #[proto(rename = ...)] attributes with scalar auto-conversion and wrapper detection
- update proto emission to honour rename overrides for struct fields and add unit coverage for the new scenarios
- adjust integration tests to treat SampleMessage.data as bytes now that the schema emits a bytes field

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691529560c9c832181c2f48e2e704ff8)