### PR TITLE
Use papaya guards as encode inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "papaya"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1215,7 @@ dependencies = [
  "crossbeam-utils",
  "fastnum",
  "inventory",
+ "papaya",
  "proptest",
  "prost",
  "prosto_derive",
@@ -1451,6 +1462,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ const_panic = { version = "0.2.15", features = [
   "derive",
 ] }
 arc-swap = { version = "1.7", optional = true }
+papaya = { version = "0.2.3", optional = true }
 smallvec.workspace = true
 
 [dev-dependencies]
@@ -101,6 +102,8 @@ solana = [
 chrono = ["dep:chrono"]
 # Lock-free atomic Arc wrappers
 arc_swap = ["dep:arc-swap"]
+# Concurrent papaya collections
+papaya = ["dep:papaya"]
 # Schema collection for build scripts
 build-schemas = ["inventory"]
 # Enable live proto dumping

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -194,6 +194,17 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
         _ => field.access.access_tokens(base.clone()),
     };
 
+    if is_papaya_hash_map_type(&field.field.ty) {
+        let tmp_ident = Ident::new(&format!("__proto_rs_field_{}_papaya", field.index), field.field.span());
+        let prelude = quote! {
+            let #tmp_ident = ::proto_rs::papaya_map_encode_input(&#access_expr);
+        };
+        return EncodeBinding {
+            prelude: Some(prelude),
+            value: quote! { #tmp_ident },
+        };
+    }
+
     if needs_encode_conversion(&field.config, &field.parsed) {
         let tmp_ident = Ident::new(&format!("__proto_rs_field_{}_converted", field.index), field.field.span());
         let converted = encode_conversion_expr(field, &access_expr);
@@ -234,6 +245,24 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
         };
         EncodeBinding { prelude: None, value: init_expr }
     }
+}
+
+fn is_papaya_hash_map_type(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+
+    let mut segments = type_path.path.segments.iter();
+    let last = match segments.next_back() {
+        Some(seg) => seg,
+        None => return false,
+    };
+
+    if last.ident != "HashMap" {
+        return false;
+    }
+
+    segments.any(|seg| seg.ident == "papaya")
 }
 
 pub fn is_value_encode_type(ty: &Type) -> bool {

--- a/protos/tests/papaya.proto
+++ b/protos/tests/papaya.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package proto_rs.tests;
+
+message PapayaCollections {
+  map<uint32, string> label_by_id = 1;
+  repeated uint64 metrics = 2;
+}
+
+message PapayaCustomCollections {
+  map<uint32, string> label_by_id = 1;
+  repeated uint32 flags = 2;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,12 @@ pub use crate::traits::ProtoExt;
 pub use crate::traits::ProtoKind;
 pub use crate::traits::ProtoShadow;
 pub use crate::traits::ProtoWire;
-// pub use crate::traits::RepeatedCollection;
 pub use crate::traits::Shadow;
 pub use crate::traits::SunOf;
 pub use crate::traits::ViewOf;
+// pub use crate::traits::RepeatedCollection;
+#[cfg(feature = "papaya")]
+pub use crate::wrappers::conc_map::papaya_map_encode_input;
 pub use crate::zero_copy::ToZeroCopy;
 pub use crate::zero_copy::ZeroCopy;
 

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -6,6 +6,11 @@ mod options;
 mod sets;
 mod vecs;
 
+#[cfg(feature = "papaya")]
+pub(crate) mod conc_map;
+#[cfg(feature = "papaya")]
+mod conc_set;
+
 #[cfg(feature = "cache_padded")]
 mod cache_padded;
 

--- a/src/wrappers/conc_map.rs
+++ b/src/wrappers/conc_map.rs
@@ -1,0 +1,726 @@
+#![cfg(feature = "papaya")]
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::hash::BuildHasher;
+use core::hash::Hash;
+
+use bytes::Buf;
+use bytes::BufMut;
+use papaya::HashMap;
+
+use super::maps::encode_map_entry_component;
+use super::maps::map_entry_field_len;
+use crate::DecodeError;
+use crate::ProtoShadow;
+use crate::ProtoWire;
+use crate::encoding::DecodeContext;
+use crate::encoding::WireType;
+use crate::encoding::decode_varint;
+use crate::encoding::encode_key;
+use crate::encoding::encode_varint;
+use crate::encoding::encoded_len_varint;
+use crate::encoding::key_len;
+use crate::traits::ProtoKind;
+
+#[cfg(feature = "std")]
+pub type PapayaMapGuard<'a, K, V, S> = papaya::HashMapRef<'a, K, V, S, papaya::LocalGuard<'a>>;
+
+#[cfg(feature = "std")]
+#[inline]
+#[allow(dead_code)]
+pub fn papaya_map_encode_input<'a, K, V, S>(map: &'a papaya::HashMap<K, V, S>) -> PapayaMapGuard<'a, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher + Default + 'a,
+{
+    map.pin()
+}
+
+impl<K, V, S> ProtoShadow<Self> for HashMap<K, V, S>
+where
+    for<'a> K: ProtoShadow<K> + ProtoWire<EncodeInput<'a> = &'a K> + 'a,
+    for<'a> V: ProtoShadow<V> + ProtoWire<EncodeInput<'a> = &'a V> + 'a,
+    for<'a> S: BuildHasher + 'a,
+{
+    type Sun<'a> = &'a HashMap<K, V, S>;
+    type OwnedSun = HashMap<K, V, S>;
+    type View<'a> = &'a HashMap<K, V, S>;
+
+    #[inline]
+    fn to_sun(self) -> Result<Self::OwnedSun, DecodeError> {
+        Ok(self)
+    }
+
+    #[inline]
+    fn from_sun(v: Self::Sun<'_>) -> Self::View<'_> {
+        v
+    }
+}
+
+impl<K, V, S> ProtoWire for HashMap<K, V, S>
+where
+    for<'a> K: ProtoWire<EncodeInput<'a> = &'a K> + Eq + Hash + 'a,
+    for<'a> V: ProtoWire<EncodeInput<'a> = &'a V> + 'a,
+    for<'a> S: BuildHasher + Default + 'a,
+{
+    type EncodeInput<'a> = crate::wrappers::conc_map::PapayaMapGuard<'a, K, V, S>;
+    const KIND: ProtoKind = ProtoKind::Repeated(&V::KIND);
+
+    #[inline(always)]
+    fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+        unsafe { Self::encoded_len_impl_raw(value) }
+    }
+
+    #[inline(always)]
+    fn encoded_len_tagged(&self, tag: u32) -> usize {
+        let guard = self.pin();
+        Self::encoded_len_tagged_impl(&guard, tag)
+    }
+
+    #[inline(always)]
+    fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+        if value.is_empty() {
+            0
+        } else {
+            value
+                .iter()
+                .map(|(k, v)| {
+                    let key_default = K::is_default_impl(&k);
+                    let key_body = if key_default { 0 } else { unsafe { K::encoded_len_impl_raw(&k) } };
+                    let key_len_total = if key_default { 0 } else { map_entry_field_len(K::WIRE_TYPE, 1, key_body) };
+                    let value_default = V::is_default_impl(&v);
+                    let value_body = if value_default { 0 } else { unsafe { V::encoded_len_impl_raw(&v) } };
+                    let value_len_total = if value_default { 0 } else { map_entry_field_len(V::WIRE_TYPE, 2, value_body) };
+                    let entry_len = key_len_total + value_len_total;
+                    key_len(tag) + encoded_len_varint(entry_len as u64) + entry_len
+                })
+                .sum()
+        }
+    }
+
+    #[inline]
+    unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+        value
+            .iter()
+            .map(|(k, v)| {
+                let key_default = K::is_default_impl(&k);
+                let key_body = if key_default { 0 } else { unsafe { K::encoded_len_impl_raw(&k) } };
+                let key_len_total = if key_default { 0 } else { map_entry_field_len(K::WIRE_TYPE, 1, key_body) };
+                let value_default = V::is_default_impl(&v);
+                let value_body = if value_default { 0 } else { unsafe { V::encoded_len_impl_raw(&v) } };
+                let value_len_total = if value_default { 0 } else { map_entry_field_len(V::WIRE_TYPE, 2, value_body) };
+                let entry_len = key_len_total + value_len_total;
+                encoded_len_varint(entry_len as u64) + entry_len
+            })
+            .sum()
+    }
+
+    #[inline]
+    fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+        panic!("Do not call encode_raw_unchecked on papaya::HashMap<K,V,S>");
+    }
+
+    #[inline]
+    fn encode_with_tag(tag: u32, guard: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+        for (k, v) in guard.iter() {
+            let key_default = K::is_default_impl(&k);
+            let key_body = if key_default { 0 } else { unsafe { K::encoded_len_impl_raw(&k) } };
+            let key_len_total = if key_default { 0 } else { map_entry_field_len(K::WIRE_TYPE, 1, key_body) };
+            let value_default = V::is_default_impl(&v);
+            let value_body = if value_default { 0 } else { unsafe { V::encoded_len_impl_raw(&v) } };
+            let value_len_total = if value_default { 0 } else { map_entry_field_len(V::WIRE_TYPE, 2, value_body) };
+            let entry_len = key_len_total + value_len_total;
+            encode_key(tag, WireType::LengthDelimited, buf);
+            encode_varint(entry_len as u64, buf);
+
+            if !key_default {
+                encode_map_entry_component::<K>(1, key_body, k, buf);
+            }
+            if !value_default {
+                encode_map_entry_component::<V>(2, value_body, v, buf);
+            }
+        }
+    }
+
+    #[inline]
+    fn decode_into(_wire_type: WireType, map: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
+        let len = decode_varint(buf)? as usize;
+        let mut slice = buf.take(len);
+        let mut key = K::proto_default();
+        let mut value = V::proto_default();
+
+        while slice.has_remaining() {
+            let (tag, wire) = crate::encoding::decode_key(&mut slice)?;
+            match tag {
+                1 => K::decode_into(wire, &mut key, &mut slice, ctx)?,
+                2 => V::decode_into(wire, &mut value, &mut slice, ctx)?,
+                _ => crate::encoding::skip_field(wire, tag, &mut slice, ctx)?,
+            }
+        }
+
+        debug_assert!(!slice.has_remaining());
+        let guard = map.pin();
+        guard.insert(key, value);
+        Ok(())
+    }
+
+    #[inline]
+    fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+        value.is_empty()
+    }
+
+    #[inline]
+    fn proto_default() -> Self {
+        HashMap::default()
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        let guard = self.pin();
+        guard.clear();
+    }
+}
+#[cfg(feature = "std")]
+macro_rules! impl_papaya_primitive_map {
+    ($K:ty, $V:ty) => {
+        impl<S> crate::ProtoWire for papaya::HashMap<$K, $V, S>
+        where
+            for<'a> S: core::hash::BuildHasher + Default + 'a,
+            $K: Eq + core::hash::Hash,
+        {
+            type EncodeInput<'a> = crate::wrappers::conc_map::PapayaMapGuard<'a, $K, $V, S>;
+            const KIND: crate::traits::ProtoKind = crate::traits::ProtoKind::Repeated(&<$V as crate::ProtoWire>::KIND);
+
+            #[inline(always)]
+            fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+                unsafe { Self::encoded_len_impl_raw(value) }
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged(&self, tag: u32) -> usize {
+                let guard = self.pin();
+                Self::encoded_len_tagged_impl(&guard, tag)
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+                if value.is_empty() {
+                    0
+                } else {
+                    value
+                        .iter()
+                        .map(|(k, v)| {
+                            let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                            let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(&k) } };
+                            let key_len_total = if key_default {
+                                0
+                            } else {
+                                crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                            };
+                            let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                            let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                            let value_len_total = if value_default {
+                                0
+                            } else {
+                                crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                            };
+                            let entry_len = key_len_total + value_len_total;
+                            crate::encoding::key_len(tag) + crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                        })
+                        .sum()
+                }
+            }
+
+            #[inline]
+            unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                value
+                    .iter()
+                    .map(|(k, v)| {
+                        let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                        let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(&k) } };
+                        let key_len_total = if key_default {
+                            0
+                        } else {
+                            crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                        };
+                        let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                        let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                        let value_len_total = if value_default {
+                            0
+                        } else {
+                            crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                        };
+                        let entry_len = key_len_total + value_len_total;
+                        crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                    })
+                    .sum()
+            }
+
+            #[inline]
+            fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+                panic!("Do not call encode_raw_unchecked on papaya::HashMap<$K,$V,S>");
+            }
+
+            #[inline]
+            fn encode_with_tag(tag: u32, guard: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+                for (k, v) in guard.iter() {
+                    let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                    let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(&k) } };
+                    let key_len_total = if key_default {
+                        0
+                    } else {
+                        crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                    };
+                    let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                    let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                    let value_len_total = if value_default {
+                        0
+                    } else {
+                        crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                    };
+                    let entry_len = key_len_total + value_len_total;
+                    crate::encoding::encode_key(tag, crate::encoding::WireType::LengthDelimited, buf);
+                    crate::encoding::encode_varint(entry_len as u64, buf);
+
+                    if !key_default {
+                        crate::wrappers::maps::encode_map_entry_component::<$K>(1, key_body, *k, buf);
+                    }
+                    if !value_default {
+                        crate::wrappers::maps::encode_map_entry_component::<$V>(2, value_body, *v, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            fn decode_into(_wire_type: crate::encoding::WireType, map: &mut Self, buf: &mut impl Buf, ctx: crate::encoding::DecodeContext) -> Result<(), crate::DecodeError> {
+                let len = crate::encoding::decode_varint(buf)? as usize;
+                let mut slice = buf.take(len);
+                let mut key = <$K as crate::ProtoWire>::proto_default();
+                let mut value = <$V as crate::ProtoWire>::proto_default();
+
+                while slice.has_remaining() {
+                    let (tag, wire) = crate::encoding::decode_key(&mut slice)?;
+                    match tag {
+                        1 => <$K as crate::ProtoWire>::decode_into(wire, &mut key, &mut slice, ctx)?,
+                        2 => <$V as crate::ProtoWire>::decode_into(wire, &mut value, &mut slice, ctx)?,
+                        _ => crate::encoding::skip_field(wire, tag, &mut slice, ctx)?,
+                    }
+                }
+
+                debug_assert!(!slice.has_remaining());
+                let guard = map.pin();
+                guard.insert(key, value);
+                Ok(())
+            }
+
+            #[inline]
+            fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                value.is_empty()
+            }
+
+            #[inline]
+            fn proto_default() -> Self {
+                papaya::HashMap::default()
+            }
+
+            #[inline]
+            fn clear(&mut self) {
+                let guard = self.pin();
+                guard.clear();
+            }
+        }
+    };
+}
+
+#[cfg(feature = "std")]
+macro_rules! impl_papaya_all_primitive_maps {
+    () => {
+        macro_rules! __for_each_val {
+            ($mac:ident, $K:ty) => {
+                $mac!($K, bool);
+                $mac!($K, i8);
+                $mac!($K, i16);
+                $mac!($K, i32);
+                $mac!($K, i64);
+                $mac!($K, u8);
+                $mac!($K, u16);
+                $mac!($K, u32);
+                $mac!($K, u64);
+                $mac!($K, f32);
+                $mac!($K, f64);
+            };
+        }
+
+        macro_rules! __emit {
+            ($K:ty, $V:ty) => {
+                impl_papaya_primitive_map!($K, $V);
+            };
+        }
+
+        __for_each_val!(__emit, bool);
+        __for_each_val!(__emit, i8);
+        __for_each_val!(__emit, i16);
+        __for_each_val!(__emit, i32);
+        __for_each_val!(__emit, i64);
+        __for_each_val!(__emit, u8);
+        __for_each_val!(__emit, u16);
+        __for_each_val!(__emit, u32);
+        __for_each_val!(__emit, u64);
+    };
+}
+
+#[cfg(feature = "std")]
+impl_papaya_all_primitive_maps!();
+
+#[cfg(feature = "std")]
+macro_rules! impl_papaya_string_map {
+    ($V:ty) => {
+        impl<S> crate::ProtoWire for papaya::HashMap<String, $V, S>
+        where
+            for<'a> S: core::hash::BuildHasher + Default + 'a,
+        {
+            type EncodeInput<'a> = crate::wrappers::conc_map::PapayaMapGuard<'a, String, $V, S>;
+            const KIND: crate::traits::ProtoKind = crate::traits::ProtoKind::Repeated(&<$V as crate::ProtoWire>::KIND);
+
+            #[inline(always)]
+            fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+                unsafe { Self::encoded_len_impl_raw(value) }
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged(&self, tag: u32) -> usize {
+                let guard = self.pin();
+                Self::encoded_len_tagged_impl(&guard, tag)
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+                if value.is_empty() {
+                    0
+                } else {
+                    value
+                        .iter()
+                        .map(|(k, v)| {
+                            let key_default = k.is_empty();
+                            let key_len = if key_default {
+                                0
+                            } else {
+                                crate::encoding::key_len(1) + crate::encoding::encoded_len_varint(k.len() as u64) + k.len()
+                            };
+                            let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                            let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                            let value_len = if value_default {
+                                0
+                            } else {
+                                crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                            };
+                            let entry_len = key_len + value_len;
+                            crate::encoding::key_len(tag) + crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                        })
+                        .sum()
+                }
+            }
+
+            #[inline]
+            unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                value
+                    .iter()
+                    .map(|(k, v)| {
+                        let key_default = k.is_empty();
+                        let key_len = if key_default {
+                            0
+                        } else {
+                            crate::encoding::key_len(1) + crate::encoding::encoded_len_varint(k.len() as u64) + k.len()
+                        };
+                        let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                        let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                        let value_len = if value_default {
+                            0
+                        } else {
+                            crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                        };
+                        let entry_len = key_len + value_len;
+                        crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                    })
+                    .sum()
+            }
+
+            #[inline]
+            fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+                panic!("Do not call encode_raw_unchecked on papaya::HashMap<String,$V,S>");
+            }
+
+            #[inline]
+            fn encode_with_tag(tag: u32, guard: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+                for (k, v) in guard.iter() {
+                    let key_default = k.is_empty();
+                    let key_len = if key_default {
+                        0
+                    } else {
+                        crate::encoding::key_len(1) + crate::encoding::encoded_len_varint(k.len() as u64) + k.len()
+                    };
+                    let value_default = <$V as crate::ProtoWire>::is_default_impl(&v);
+                    let value_body = if value_default { 0 } else { unsafe { <$V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                    let value_len = if value_default {
+                        0
+                    } else {
+                        crate::wrappers::maps::map_entry_field_len(<$V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                    };
+                    let entry_len = key_len + value_len;
+                    crate::encoding::encode_key(tag, crate::encoding::WireType::LengthDelimited, buf);
+                    crate::encoding::encode_varint(entry_len as u64, buf);
+
+                    if !key_default {
+                        crate::encoding::encode_key(1, crate::encoding::WireType::LengthDelimited, buf);
+                        crate::encoding::encode_varint(k.len() as u64, buf);
+                        buf.put_slice(k.as_bytes());
+                    }
+
+                    if !value_default {
+                        crate::wrappers::maps::encode_map_entry_component::<$V>(2, value_body, *v, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            fn decode_into(_wire_type: crate::encoding::WireType, map: &mut Self, buf: &mut impl Buf, ctx: crate::encoding::DecodeContext) -> Result<(), crate::DecodeError> {
+                let len = crate::encoding::decode_varint(buf)? as usize;
+                let mut slice = buf.take(len);
+                let mut key = String::new();
+                let mut value = <$V as crate::ProtoWire>::proto_default();
+
+                while slice.has_remaining() {
+                    let (tag, wire) = crate::encoding::decode_key(&mut slice)?;
+                    match tag {
+                        1 => {
+                            let slen = crate::encoding::decode_varint(&mut slice)? as usize;
+                            let mut bytes = Vec::with_capacity(slen);
+                            bytes.resize(slen, 0);
+                            slice.copy_to_slice(&mut bytes);
+                            key = String::from_utf8(bytes).map_err(|_| crate::DecodeError::new("invalid UTF-8 string key"))?;
+                        }
+                        2 => <$V as crate::ProtoWire>::decode_into(wire, &mut value, &mut slice, ctx)?,
+                        _ => crate::encoding::skip_field(wire, tag, &mut slice, ctx)?,
+                    }
+                }
+
+                debug_assert!(!slice.has_remaining());
+                let guard = map.pin();
+                guard.insert(key, value);
+                Ok(())
+            }
+
+            #[inline]
+            fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                value.is_empty()
+            }
+
+            #[inline]
+            fn proto_default() -> Self {
+                papaya::HashMap::default()
+            }
+
+            #[inline]
+            fn clear(&mut self) {
+                let guard = self.pin();
+                guard.clear();
+            }
+        }
+    };
+}
+
+#[cfg(feature = "std")]
+impl_papaya_string_map!(bool);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(i8);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(i16);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(i32);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(i64);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(u8);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(u16);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(u32);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(u64);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(f32);
+#[cfg(feature = "std")]
+impl_papaya_string_map!(f64);
+
+#[cfg(feature = "std")]
+macro_rules! impl_papaya_copykey_map {
+    ($K:ty) => {
+        impl<V, S> crate::ProtoWire for papaya::HashMap<$K, V, S>
+        where
+            for<'a> S: core::hash::BuildHasher + Default + 'a,
+            for<'a> $K: crate::ProtoWire<EncodeInput<'a> = $K> + Eq + core::hash::Hash + 'a,
+            for<'a> V: crate::ProtoWire<EncodeInput<'a> = &'a V> + 'a,
+        {
+            type EncodeInput<'a> = crate::wrappers::conc_map::PapayaMapGuard<'a, $K, V, S>;
+            const KIND: crate::traits::ProtoKind = crate::traits::ProtoKind::Repeated(&<V as crate::ProtoWire>::KIND);
+
+            #[inline(always)]
+            fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+                unsafe { Self::encoded_len_impl_raw(value) }
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged(&self, tag: u32) -> usize {
+                let guard = self.pin();
+                Self::encoded_len_tagged_impl(&guard, tag)
+            }
+
+            #[inline(always)]
+            fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+                if value.is_empty() {
+                    0
+                } else {
+                    value
+                        .iter()
+                        .map(|(k, v)| {
+                            let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                            let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(k) } };
+                            let key_len_total = if key_default {
+                                0
+                            } else {
+                                crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                            };
+                            let value_default = <V as crate::ProtoWire>::is_default_impl(&v);
+                            let value_body = if value_default { 0 } else { unsafe { <V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                            let value_len_total = if value_default {
+                                0
+                            } else {
+                                crate::wrappers::maps::map_entry_field_len(<V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                            };
+                            let entry_len = key_len_total + value_len_total;
+                            crate::encoding::key_len(tag) + crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                        })
+                        .sum()
+                }
+            }
+
+            #[inline]
+            unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                value
+                    .iter()
+                    .map(|(k, v)| {
+                        let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                        let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(k) } };
+                        let key_len_total = if key_default {
+                            0
+                        } else {
+                            crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                        };
+                        let value_default = <V as crate::ProtoWire>::is_default_impl(&v);
+                        let value_body = if value_default { 0 } else { unsafe { <V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                        let value_len_total = if value_default {
+                            0
+                        } else {
+                            crate::wrappers::maps::map_entry_field_len(<V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                        };
+                        let entry_len = key_len_total + value_len_total;
+                        crate::encoding::encoded_len_varint(entry_len as u64) + entry_len
+                    })
+                    .sum()
+            }
+
+            #[inline]
+            fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+                panic!("Do not call encode_raw_unchecked on papaya::HashMap<$K,V,S>");
+            }
+
+            #[inline]
+            fn encode_with_tag(tag: u32, guard: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+                for (k, v) in guard.iter() {
+                    let key_default = <$K as crate::ProtoWire>::is_default_impl(&k);
+                    let key_body = if key_default { 0 } else { unsafe { <$K as crate::ProtoWire>::encoded_len_impl_raw(k) } };
+                    let key_len_total = if key_default {
+                        0
+                    } else {
+                        crate::wrappers::maps::map_entry_field_len(<$K as crate::ProtoWire>::WIRE_TYPE, 1, key_body)
+                    };
+                    let value_default = <V as crate::ProtoWire>::is_default_impl(&v);
+                    let value_body = if value_default { 0 } else { unsafe { <V as crate::ProtoWire>::encoded_len_impl_raw(&v) } };
+                    let value_len_total = if value_default {
+                        0
+                    } else {
+                        crate::wrappers::maps::map_entry_field_len(<V as crate::ProtoWire>::WIRE_TYPE, 2, value_body)
+                    };
+                    let entry_len = key_len_total + value_len_total;
+                    crate::encoding::encode_key(tag, crate::encoding::WireType::LengthDelimited, buf);
+                    crate::encoding::encode_varint(entry_len as u64, buf);
+
+                    if !key_default {
+                        crate::wrappers::maps::encode_map_entry_component::<$K>(1, key_body, *k, buf);
+                    }
+                    if !value_default {
+                        crate::wrappers::maps::encode_map_entry_component::<V>(2, value_body, v, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            fn decode_into(_wire_type: crate::encoding::WireType, map: &mut Self, buf: &mut impl Buf, ctx: crate::encoding::DecodeContext) -> Result<(), crate::DecodeError> {
+                let len = crate::encoding::decode_varint(buf)? as usize;
+                let mut slice = buf.take(len);
+                let mut key = <$K as crate::ProtoWire>::proto_default();
+                let mut value = <V as crate::ProtoWire>::proto_default();
+
+                while slice.has_remaining() {
+                    let (tag, wire) = crate::encoding::decode_key(&mut slice)?;
+                    match tag {
+                        1 => <$K as crate::ProtoWire>::decode_into(wire, &mut key, &mut slice, ctx)?,
+                        2 => <V as crate::ProtoWire>::decode_into(wire, &mut value, &mut slice, ctx)?,
+                        _ => crate::encoding::skip_field(wire, tag, &mut slice, ctx)?,
+                    }
+                }
+
+                debug_assert!(!slice.has_remaining());
+                let guard = map.pin();
+                guard.insert(key, value);
+                Ok(())
+            }
+
+            #[inline]
+            fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                value.is_empty()
+            }
+
+            #[inline]
+            fn proto_default() -> Self {
+                papaya::HashMap::default()
+            }
+
+            #[inline]
+            fn clear(&mut self) {
+                let guard = self.pin();
+                guard.clear();
+            }
+        }
+    };
+}
+
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(u8);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(u16);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(u32);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(u64);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(i8);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(i16);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(i32);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(i64);
+#[cfg(feature = "std")]
+impl_papaya_copykey_map!(bool);

--- a/src/wrappers/conc_set.rs
+++ b/src/wrappers/conc_set.rs
@@ -1,0 +1,331 @@
+#![cfg(feature = "papaya")]
+
+use core::hash::BuildHasher;
+use core::hash::Hash;
+
+use bytes::Buf;
+use bytes::BufMut;
+use papaya::HashSet;
+
+use crate::DecodeError;
+use crate::ProtoShadow;
+use crate::ProtoWire;
+use crate::encoding::DecodeContext;
+use crate::encoding::WireType;
+use crate::encoding::decode_varint;
+use crate::encoding::encode_key;
+use crate::encoding::encode_varint;
+use crate::encoding::encoded_len_varint;
+use crate::encoding::key_len;
+use crate::traits::ProtoKind;
+
+impl<T, S> ProtoShadow<Self> for HashSet<T, S>
+where
+    for<'a> T: ProtoShadow<T> + ProtoWire<EncodeInput<'a> = &'a T> + 'a,
+    for<'a> S: BuildHasher + 'a,
+{
+    type Sun<'a> = &'a HashSet<T, S>;
+    type OwnedSun = HashSet<T, S>;
+    type View<'a> = &'a HashSet<T, S>;
+
+    #[inline]
+    fn to_sun(self) -> Result<Self::OwnedSun, DecodeError> {
+        Ok(self)
+    }
+
+    #[inline]
+    fn from_sun(v: Self::Sun<'_>) -> Self::View<'_> {
+        v
+    }
+}
+
+impl<T, S> ProtoWire for HashSet<T, S>
+where
+    for<'a> T: ProtoWire<EncodeInput<'a> = &'a T> + Eq + Hash + 'a,
+    for<'a> S: BuildHasher + Default + 'a,
+{
+    type EncodeInput<'a> = &'a HashSet<T, S>;
+    const KIND: ProtoKind = ProtoKind::for_vec(&T::KIND);
+    const _REPEATED_SUPPORT: Option<&'static str> = Some("papaya::HashSet");
+
+    #[inline(always)]
+    fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+        unsafe { Self::encoded_len_impl_raw(value) }
+    }
+
+    #[inline(always)]
+    fn encoded_len_tagged(&self, tag: u32) -> usize
+    where
+        for<'b> Self: ProtoWire<EncodeInput<'b> = &'b Self>,
+    {
+        Self::encoded_len_tagged_impl(&self, tag)
+    }
+
+    #[inline(always)]
+    fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+        match T::KIND {
+            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => {
+                if value.is_empty() {
+                    0
+                } else {
+                    let body = unsafe { Self::encoded_len_impl_raw(value) };
+                    key_len(tag) + encoded_len_varint(body as u64) + body
+                }
+            }
+            ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => {
+                let n = value.len();
+                if n == 0 {
+                    0
+                } else {
+                    let guard = value.pin();
+                    let body: usize = guard
+                        .iter()
+                        .map(|m| {
+                            let len = unsafe { T::encoded_len_impl_raw(&m) };
+                            encoded_len_varint(len as u64) + len
+                        })
+                        .sum();
+                    key_len(tag) * n + body
+                }
+            }
+            ProtoKind::Repeated(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    #[inline]
+    unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+        let guard = value.pin();
+        match T::KIND {
+            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => guard.iter().map(|v| unsafe { T::encoded_len_impl_raw(&v) }).sum(),
+            ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => guard
+                .iter()
+                .map(|m| {
+                    let len = unsafe { T::encoded_len_impl_raw(&m) };
+                    encoded_len_varint(len as u64) + len
+                })
+                .sum(),
+            ProtoKind::Repeated(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    #[inline]
+    fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+        panic!("Do not call encode_raw_unchecked on papaya::HashSet<T,S>");
+    }
+
+    #[inline]
+    fn encode_with_tag(tag: u32, value: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+        match T::KIND {
+            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => {
+                if value.is_empty() {
+                    return;
+                }
+                let guard = value.pin();
+                encode_key(tag, WireType::LengthDelimited, buf);
+                let body_len = guard.iter().map(|v| T::encoded_len_impl(&v)).sum::<usize>();
+                encode_varint(body_len as u64, buf);
+                for v in guard.iter() {
+                    T::encode_raw_unchecked(v, buf);
+                }
+            }
+            ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => {
+                let guard = value.pin();
+                for m in guard.iter() {
+                    let len = unsafe { T::encoded_len_impl_raw(&m) };
+                    encode_key(tag, WireType::LengthDelimited, buf);
+                    encode_varint(len as u64, buf);
+                    T::encode_raw_unchecked(m, buf);
+                }
+            }
+            ProtoKind::Repeated(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    #[inline]
+    fn decode_into(wire_type: WireType, set: &mut Self, buf: &mut impl Buf, ctx: DecodeContext) -> Result<(), DecodeError> {
+        let guard = set.pin();
+        match T::KIND {
+            ProtoKind::Primitive(_) | ProtoKind::SimpleEnum => {
+                if wire_type == WireType::LengthDelimited {
+                    let len = decode_varint(buf)? as usize;
+                    let mut slice = buf.take(len);
+                    while slice.has_remaining() {
+                        let mut v = T::proto_default();
+                        T::decode_into(T::WIRE_TYPE, &mut v, &mut slice, ctx)?;
+                        guard.insert(v);
+                    }
+                    debug_assert!(!slice.has_remaining());
+                } else {
+                    let mut v = T::proto_default();
+                    T::decode_into(wire_type, &mut v, buf, ctx)?;
+                    guard.insert(v);
+                }
+                Ok(())
+            }
+            ProtoKind::String | ProtoKind::Bytes | ProtoKind::Message => {
+                let mut v = T::proto_default();
+                T::decode_into(wire_type, &mut v, buf, ctx)?;
+                guard.insert(v);
+                Ok(())
+            }
+            ProtoKind::Repeated(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    #[inline]
+    fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+        value.is_empty()
+    }
+
+    #[inline]
+    fn proto_default() -> Self {
+        HashSet::default()
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        let guard = self.pin();
+        guard.clear();
+    }
+}
+#[cfg(feature = "std")]
+macro_rules! impl_papaya_hashset_for_copy {
+    ($($ty:ty => $kind:expr),* $(,)?) => {
+        $(
+            impl<S> crate::ProtoWire for papaya::HashSet<$ty, S>
+            where
+                for<'a> S: core::hash::BuildHasher + Default + 'a,
+            {
+                type EncodeInput<'a> = &'a papaya::HashSet<$ty, S>;
+                const KIND: crate::traits::ProtoKind = $kind;
+                const _REPEATED_SUPPORT: Option<&'static str> = Some("papaya::HashSet");
+
+                #[inline(always)]
+                fn encoded_len_impl(value: &Self::EncodeInput<'_>) -> usize {
+                    unsafe { Self::encoded_len_impl_raw(value) }
+                }
+
+                #[inline(always)]
+                fn encoded_len_tagged(&self, tag: u32) -> usize
+                where
+                    for<'b> Self: crate::ProtoWire<EncodeInput<'b> = &'b Self>,
+                {
+                    Self::encoded_len_tagged_impl(&self, tag)
+                }
+
+                #[inline(always)]
+                fn encoded_len_tagged_impl(value: &Self::EncodeInput<'_>, tag: u32) -> usize {
+                    if value.is_empty() {
+                        0
+                    } else {
+                        let guard = value.pin();
+                        let body = guard
+                            .iter()
+                            .map(|v| <$ty as crate::ProtoWire>::encoded_len_impl(&v))
+                            .sum::<usize>();
+                        crate::encoding::key_len(tag) + crate::encoding::encoded_len_varint(body as u64) + body
+                    }
+                }
+
+                #[inline]
+                unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                    let guard = value.pin();
+                    guard
+                        .iter()
+                        .map(|v| <$ty as crate::ProtoWire>::encoded_len_impl(&v))
+                        .sum::<usize>()
+                }
+
+                #[inline]
+                fn encode_raw_unchecked(_value: Self::EncodeInput<'_>, _buf: &mut impl BufMut) {
+                    panic!("Do not call encode_raw_unchecked on papaya::HashSet<$ty,S>");
+                }
+
+                #[inline]
+                fn encode_with_tag(tag: u32, value: Self::EncodeInput<'_>, buf: &mut impl BufMut) {
+                    if value.is_empty() {
+                        return;
+                    }
+                    let guard = value.pin();
+                    crate::encoding::encode_key(tag, crate::encoding::WireType::LengthDelimited, buf);
+                    let body_len = guard
+                        .iter()
+                        .map(|v| <$ty as crate::ProtoWire>::encoded_len_impl(&v))
+                        .sum::<usize>();
+                    crate::encoding::encode_varint(body_len as u64, buf);
+                    for v in guard.iter() {
+                        <$ty as crate::ProtoWire>::encode_raw_unchecked(*v, buf);
+                    }
+                }
+
+                #[inline]
+                fn decode_into(
+                    wire_type: crate::encoding::WireType,
+                    set: &mut Self,
+                    buf: &mut impl Buf,
+                    ctx: crate::encoding::DecodeContext,
+                ) -> Result<(), crate::DecodeError> {
+                    let guard = set.pin();
+                    if wire_type == crate::encoding::WireType::LengthDelimited {
+                        let len = crate::encoding::decode_varint(buf)? as usize;
+                        let mut slice = buf.take(len);
+                        while slice.has_remaining() {
+                            let mut v = <$ty as crate::ProtoWire>::proto_default();
+                            <$ty as crate::ProtoWire>::decode_into(
+                                <$ty as crate::ProtoWire>::WIRE_TYPE,
+                                &mut v,
+                                &mut slice,
+                                ctx,
+                            )?;
+                            guard.insert(v);
+                        }
+                        debug_assert!(!slice.has_remaining());
+                        Ok(())
+                    } else {
+                        let mut v = <$ty as crate::ProtoWire>::proto_default();
+                        <$ty as crate::ProtoWire>::decode_into(wire_type, &mut v, buf, ctx)?;
+                        guard.insert(v);
+                        Ok(())
+                    }
+                }
+
+                #[inline]
+                fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                    value.is_empty()
+                }
+
+                #[inline]
+                fn proto_default() -> Self {
+                    papaya::HashSet::default()
+                }
+
+                #[inline]
+                fn clear(&mut self) {
+                    let guard = self.pin();
+                    guard.clear();
+                }
+            }
+        )*
+    };
+}
+
+#[cfg(feature = "std")]
+impl_papaya_hashset_for_copy! {
+    bool => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::Bool),
+    i8   => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::I8),
+    i16  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::I16),
+    i32  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::I32),
+    i64  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::I64),
+    u8   => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::U8),
+    u16  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::U16),
+    u32  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::U32),
+    u64  => crate::traits::ProtoKind::Primitive(crate::traits::PrimitiveKind::U64),
+}

--- a/tests/papaya_roundtrip.rs
+++ b/tests/papaya_roundtrip.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "papaya")]
+
+use std::hash::BuildHasherDefault;
+use std::hash::Hasher;
+
+use proto_rs::ProtoExt;
+use proto_rs::proto_message;
+
+#[proto_message(proto_path = "protos/tests/papaya.proto")]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PapayaCollections {
+    #[proto(tag = 1)]
+    pub label_by_id: papaya::HashMap<u32, String>,
+    #[proto(tag = 2)]
+    pub metrics: papaya::HashSet<u64>,
+}
+
+#[derive(Default)]
+pub struct IdentityHasher(u64);
+
+impl Hasher for IdentityHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.0 = self.0.wrapping_mul(0x100_0000_01b3).wrapping_add(u64::from(*byte));
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+type IdentityBuildHasher = BuildHasherDefault<IdentityHasher>;
+
+#[proto_message(proto_path = "protos/tests/papaya.proto")]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PapayaCustomCollections {
+    #[proto(tag = 1)]
+    pub label_by_id: papaya::HashMap<u32, String, IdentityBuildHasher>,
+    #[proto(tag = 2)]
+    pub flags: papaya::HashSet<u32, IdentityBuildHasher>,
+}
+
+#[test]
+fn papaya_hash_collections_roundtrip() {
+    let message = PapayaCollections::default();
+
+    {
+        let map_guard = message.label_by_id.pin();
+        map_guard.insert(1, "alpha".to_string());
+        map_guard.insert(2, "beta".to_string());
+    }
+
+    {
+        let set_guard = message.metrics.pin();
+        set_guard.insert(7);
+        set_guard.insert(11);
+    }
+
+    let encoded = PapayaCollections::encode_to_vec(&message);
+    let decoded = PapayaCollections::decode(&encoded[..]).expect("decode papaya collections");
+
+    assert_eq!(decoded, message);
+
+    let guard = decoded.label_by_id.pin();
+    assert_eq!(guard.iter().count(), 2);
+    assert_eq!(guard.get(&1).map(String::as_str), Some("alpha"));
+}
+
+#[test]
+fn papaya_hash_collections_support_custom_hashers() {
+    let message = PapayaCustomCollections::default();
+
+    {
+        let map_guard = message.label_by_id.pin();
+        map_guard.insert(3, "three".to_string());
+        map_guard.insert(5, "five".to_string());
+    }
+
+    {
+        let set_guard = message.flags.pin();
+        set_guard.insert(13);
+        set_guard.insert(17);
+    }
+
+    let encoded = PapayaCustomCollections::encode_to_vec(&message);
+    let decoded = PapayaCustomCollections::decode(&encoded[..]).expect("decode papaya custom collections");
+
+    assert_eq!(decoded, message);
+}


### PR DESCRIPTION
## Summary
- add an optional `papaya` feature and dependency
- provide papaya-backed concurrent HashMap and HashSet wrappers with coverage for copy-friendly key/value combinations
- add papaya collection round-trip protobuf fixtures and tests
- switch papaya map encode inputs to use pinned guards instead of borrowing the map directly, preventing double pinning before encode

## Testing
- cargo test --features papaya

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153a060c408321af23caa81dcbc967)