### PR TITLE
Support sun-backed complex enums and Solana transaction error proto fixes

### DIFF
--- a/crates/prosto_derive/src/proto_message/structs.rs
+++ b/crates/prosto_derive/src/proto_message/structs.rs
@@ -47,6 +47,7 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
                     parsed,
                     proto_ty,
                     decode_ty,
+                    owned_access: false,
                 }
             })
             .collect::<Vec<_>>(),
@@ -68,6 +69,7 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
                     parsed,
                     proto_ty,
                     decode_ty,
+                    owned_access: false,
                 }
             })
             .collect::<Vec<_>>(),

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -25,6 +25,7 @@ pub struct FieldInfo<'a> {
     pub parsed: ParsedFieldType,
     pub proto_ty: Type,
     pub decode_ty: Type,
+    pub owned_access: bool,
 }
 
 #[derive(Clone)]
@@ -222,7 +223,9 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
                 quote! { (#access_expr).as_ref().map(|inner| inner) }
             }
         } else if matches!(field.access, FieldAccess::Direct(_)) {
-            if is_value_encode_type(proto_ty) {
+            if field.owned_access {
+                access_expr.clone()
+            } else if is_value_encode_type(proto_ty) {
                 quote! { *(#access_expr) }
             } else {
                 access_expr.clone()


### PR DESCRIPTION
## Summary
- allow `proto_message` complex enums to support `sun` targets and reuse merge loop decoding
- mark struct fields as borrowed for encoding and honor owned access requirements when emitting encode code
- wire Solana transaction error proto to `InstructionErrorProto` and add roundtrip tests gated behind the `solana` feature

## Testing
- cargo test
- cargo test --features solana

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916090a32a48321a4b5df7616fcd3a7)