### PR TITLE
Support reference suns for complex enums

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -69,6 +69,7 @@ pub struct UnifiedProtoConfig {
 pub struct SunConfig {
     pub ty: Type,
     pub message_ident: String,
+    pub by_ref: bool,
 }
 
 impl UnifiedProtoConfig {
@@ -168,9 +169,14 @@ impl UnifiedProtoConfig {
     }
 
     fn push_sun(&mut self, ty: Type) {
+        let by_ref = is_reference_sun(&ty);
         let ty = normalize_sun_type(ty);
         let message_ident = extract_type_ident(&ty).expect("sun attribute expects a type path");
-        self.suns.push(SunConfig { ty, message_ident });
+        self.suns.push(SunConfig {
+            ty,
+            message_ident,
+            by_ref,
+        });
     }
 }
 
@@ -180,6 +186,15 @@ fn normalize_sun_type(ty: Type) -> Type {
         Type::Group(group) => normalize_sun_type(*group.elem),
         Type::Paren(paren) => normalize_sun_type(*paren.elem),
         other => other,
+    }
+}
+
+fn is_reference_sun(ty: &Type) -> bool {
+    match ty {
+        Type::Reference(_) => true,
+        Type::Group(group) => is_reference_sun(&group.elem),
+        Type::Paren(paren) => is_reference_sun(&paren.elem),
+        _ => false,
     }
 }
 

--- a/crates/prosto_derive/src/proto_message/complex_enums.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enums.rs
@@ -56,10 +56,18 @@ pub(super) fn generate_complex_enum_impl(input: &DeriveInput, item_enum: &ItemEn
 
     let decode_into_body = if let Some(sun) = config.suns.first() {
         let target_ty = &sun.ty;
-        quote! {
-            let decoded = <#target_ty as ::proto_rs::ProtoExt>::decode_length_delimited(buf, ctx)?;
-            *value = <Self as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(decoded);
-            Ok(())
+        if sun.by_ref {
+            quote! {
+                let decoded = <#target_ty as ::proto_rs::ProtoExt>::decode_length_delimited(buf, ctx)?;
+                *value = <Self as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(&decoded);
+                Ok(())
+            }
+        } else {
+            quote! {
+                let decoded = <#target_ty as ::proto_rs::ProtoExt>::decode_length_delimited(buf, ctx)?;
+                *value = <Self as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(decoded);
+                Ok(())
+            }
         }
     } else {
         quote! {


### PR DESCRIPTION
## Summary
- track whether proto_message sun attributes are references
- decode complex enums with sun types using either owned or reference tactics based on attribute

## Testing
- cargo test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca3ac1810832186ad714e71b29d65)