### PR TITLE
Generate ProtoWire delegations for sun types

### DIFF
--- a/crates/prosto_derive/src/proto_message/complex_enums.rs
+++ b/crates/prosto_derive/src/proto_message/complex_enums.rs
@@ -188,11 +188,80 @@ pub(super) fn generate_complex_enum_impl(input: &DeriveInput, item_enum: &ItemEn
         }
     };
 
+    let delegating_impls = if config.has_suns() {
+        let shadow_ty = quote! { #name #ty_generics };
+        let impls = config
+            .suns
+            .iter()
+            .map(|sun| {
+                let target_ty = &sun.ty;
+                quote! {
+                    impl ::proto_rs::ProtoWire for #target_ty {
+                        type EncodeInput<'a> = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::Sun<'a>;
+                        const KIND: ::proto_rs::ProtoKind = <#shadow_ty as ::proto_rs::ProtoWire>::KIND;
+
+                        #[inline(always)]
+                        fn proto_default() -> Self {
+                            <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(
+                                <#shadow_ty as ::proto_rs::ProtoWire>::proto_default(),
+                            )
+                            .expect("default shadow must be decodable")
+                        }
+
+                        #[inline(always)]
+                        fn clear(&mut self) {
+                            *self = Self::proto_default();
+                        }
+
+                        #[inline(always)]
+                        fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::is_default_impl(&shadow)
+                        }
+
+                        #[inline(always)]
+                        unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encoded_len_impl_raw(&shadow)
+                        }
+
+                        #[inline(always)]
+                        fn encode_raw_unchecked(
+                            value: Self::EncodeInput<'_>,
+                            buf: &mut impl ::proto_rs::bytes::BufMut,
+                        ) {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encode_raw_unchecked(shadow, buf)
+                        }
+
+                        #[inline(always)]
+                        fn decode_into(
+                            wire_type: ::proto_rs::encoding::WireType,
+                            value: &mut Self,
+                            buf: &mut impl ::proto_rs::bytes::Buf,
+                            ctx: ::proto_rs::encoding::DecodeContext,
+                        ) -> Result<(), ::proto_rs::DecodeError> {
+                            let mut shadow = <#shadow_ty as ::proto_rs::ProtoWire>::proto_default();
+                            <#shadow_ty as ::proto_rs::ProtoWire>::decode_into(wire_type, &mut shadow, buf, ctx)?;
+                            *value = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(shadow)?;
+                            Ok(())
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        quote! { #(#impls)* }
+    } else {
+        quote! {}
+    };
+
     Ok(quote! {
         #enum_item
         #proto_shadow_impl
         #proto_ext_impl
         #proto_wire_impl
+        #delegating_impls
     })
 }
 

--- a/crates/prosto_derive/src/proto_message/enums.rs
+++ b/crates/prosto_derive/src/proto_message/enums.rs
@@ -207,11 +207,80 @@ pub(super) fn generate_simple_enum_impl(input: &DeriveInput, item_enum: &ItemEnu
         }
     };
 
+    let delegating_impls = if config.has_suns() {
+        let shadow_ty = quote! { #name #ty_generics };
+        let impls = config
+            .suns
+            .iter()
+            .map(|sun| {
+                let target_ty = &sun.ty;
+                quote! {
+                    impl ::proto_rs::ProtoWire for #target_ty {
+                        type EncodeInput<'a> = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::Sun<'a>;
+                        const KIND: ::proto_rs::ProtoKind = <#shadow_ty as ::proto_rs::ProtoWire>::KIND;
+
+                        #[inline(always)]
+                        fn proto_default() -> Self {
+                            <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(
+                                <#shadow_ty as ::proto_rs::ProtoWire>::proto_default(),
+                            )
+                            .expect("default shadow must be decodable")
+                        }
+
+                        #[inline(always)]
+                        fn clear(&mut self) {
+                            *self = Self::proto_default();
+                        }
+
+                        #[inline(always)]
+                        fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::is_default_impl(&shadow)
+                        }
+
+                        #[inline(always)]
+                        unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encoded_len_impl_raw(&shadow)
+                        }
+
+                        #[inline(always)]
+                        fn encode_raw_unchecked(
+                            value: Self::EncodeInput<'_>,
+                            buf: &mut impl ::proto_rs::bytes::BufMut,
+                        ) {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encode_raw_unchecked(shadow, buf)
+                        }
+
+                        #[inline(always)]
+                        fn decode_into(
+                            wire_type: ::proto_rs::encoding::WireType,
+                            value: &mut Self,
+                            buf: &mut impl ::proto_rs::bytes::Buf,
+                            ctx: ::proto_rs::encoding::DecodeContext,
+                        ) -> Result<(), ::proto_rs::DecodeError> {
+                            let mut shadow = <#shadow_ty as ::proto_rs::ProtoWire>::proto_default();
+                            <#shadow_ty as ::proto_rs::ProtoWire>::decode_into(wire_type, &mut shadow, buf, ctx)?;
+                            *value = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(shadow)?;
+                            Ok(())
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        quote! { #(#impls)* }
+    } else {
+        quote! {}
+    };
+
     quote! {
         #enum_item
         #proto_shadow_impl
         #proto_ext_impl
         #proto_wire_impl
         #try_from_impl
+        #delegating_impls
     }
 }

--- a/crates/prosto_derive/src/proto_message/structs.rs
+++ b/crates/prosto_derive/src/proto_message/structs.rs
@@ -402,7 +402,7 @@ fn generate_proto_wire_impl(
         quote! { <Self as ::proto_rs::ProtoShadow<Self>>::View<'b> }
     };
 
-    quote! {
+    let shadow_impl = quote! {
         impl #impl_generics ::proto_rs::ProtoWire for #name #ty_generics #where_clause {
             type EncodeInput<'b> = #encode_input_ty;
             const KIND: ::proto_rs::ProtoKind = ::proto_rs::ProtoKind::Message;
@@ -462,5 +462,73 @@ fn generate_proto_wire_impl(
                 )
             }
         }
+    };
+
+    if config.has_suns() {
+        let shadow_ty = quote! { #name #ty_generics };
+        let delegating_impls = config
+            .suns
+            .iter()
+            .map(|sun| {
+                let target_ty = &sun.ty;
+                quote! {
+                    impl ::proto_rs::ProtoWire for #target_ty {
+                        type EncodeInput<'a> = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::Sun<'a>;
+                        const KIND: ::proto_rs::ProtoKind = <#shadow_ty as ::proto_rs::ProtoWire>::KIND;
+
+                        #[inline(always)]
+                        fn proto_default() -> Self {
+                            <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(
+                                <#shadow_ty as ::proto_rs::ProtoWire>::proto_default(),
+                            )
+                            .expect("default shadow must be decodable")
+                        }
+
+                        #[inline(always)]
+                        fn clear(&mut self) {
+                            *self = Self::proto_default();
+                        }
+
+                        #[inline(always)]
+                        fn is_default_impl(value: &Self::EncodeInput<'_>) -> bool {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::is_default_impl(&shadow)
+                        }
+
+                        #[inline(always)]
+                        unsafe fn encoded_len_impl_raw(value: &Self::EncodeInput<'_>) -> usize {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(*value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encoded_len_impl_raw(&shadow)
+                        }
+
+                        #[inline(always)]
+                        fn encode_raw_unchecked(
+                            value: Self::EncodeInput<'_>,
+                            buf: &mut impl ::proto_rs::bytes::BufMut,
+                        ) {
+                            let shadow = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::from_sun(value);
+                            <#shadow_ty as ::proto_rs::ProtoWire>::encode_raw_unchecked(shadow, buf)
+                        }
+
+                        #[inline(always)]
+                        fn decode_into(
+                            wire_type: ::proto_rs::encoding::WireType,
+                            value: &mut Self,
+                            buf: &mut impl ::proto_rs::bytes::Buf,
+                            ctx: ::proto_rs::encoding::DecodeContext,
+                        ) -> Result<(), ::proto_rs::DecodeError> {
+                            let mut shadow = <#shadow_ty as ::proto_rs::ProtoWire>::proto_default();
+                            <#shadow_ty as ::proto_rs::ProtoWire>::decode_into(wire_type, &mut shadow, buf, ctx)?;
+                            *value = <#shadow_ty as ::proto_rs::ProtoShadow<#target_ty>>::to_sun(shadow)?;
+                            Ok(())
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        quote! { #shadow_impl #(#delegating_impls)* }
+    } else {
+        quote! { #shadow_impl }
     }
 }


### PR DESCRIPTION
## Summary
- generate ProtoWire delegations for macro `sun` targets so custom conversions implement ProtoWire alongside their shadows
- wire encoders reuse shadow implementations while converting via ProtoShadow to avoid duplicated logic for structs and enums

## Testing
- cargo test --all-features


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf804d0208321b94393e7a9a2be22)