### PR TITLE
Map atomic types to proto primitives

### DIFF
--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -249,6 +249,15 @@ fn parse_primitive_or_custom(ty: &Type) -> ParsedFieldType {
         Type::Path(path) => {
             if let Some(id) = last_ident(path) {
                 return match id.to_string().as_str() {
+                    "AtomicBool" => numeric_scalar(ty.clone(), parse_quote! { bool }, "bool"),
+                    "AtomicU8" | "AtomicU16" | "AtomicU32" | "AtomicUsize" => {
+                        numeric_scalar(ty.clone(), parse_quote! { u32 }, "uint32")
+                    }
+                    "AtomicU64" => numeric_scalar(ty.clone(), parse_quote! { u64 }, "uint64"),
+                    "AtomicI8" | "AtomicI16" | "AtomicI32" | "AtomicIsize" => {
+                        numeric_scalar(ty.clone(), parse_quote! { i32 }, "int32")
+                    }
+                    "AtomicI64" => numeric_scalar(ty.clone(), parse_quote! { i64 }, "int64"),
                     "u8" | "u16" | "u32" => numeric_scalar(ty.clone(), parse_quote! { u32 }, "uint32"),
                     "u64" | "usize" => numeric_scalar(ty.clone(), parse_quote! { u64 }, "uint64"),
                     "i8" | "i16" | "i32" => numeric_scalar(ty.clone(), parse_quote! { i32 }, "int32"),

--- a/protos/atomic_test.proto
+++ b/protos/atomic_test.proto
@@ -3,14 +3,14 @@ syntax = "proto3";
 package atomic_test;
 
 message AtomicWrapper {
-  AtomicBool f1 = 1;
-  AtomicU8 f2 = 2;
-  AtomicU16 f3 = 3;
-  AtomicU32 f4 = 4;
-  AtomicU64 f5 = 5;
-  AtomicI8 f6 = 6;
-  AtomicI16 f7 = 7;
-  AtomicI32 f8 = 8;
-  AtomicI64 f9 = 9;
+  bool f1 = 1;
+  uint32 f2 = 2;
+  uint32 f3 = 3;
+  uint32 f4 = 4;
+  uint64 f5 = 5;
+  int32 f6 = 6;
+  int32 f7 = 7;
+  int32 f8 = 8;
+  int64 f9 = 9;
 }
 


### PR DESCRIPTION
## Summary
- map Rust atomic field types to their protobuf primitive equivalents during type parsing
- update the atomic proto fixture to use primitive scalar field definitions

## Testing
- cargo test --locked

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d06d546888321952d5a8635dac1c3)