### PR TITLE
Handle optional atomic bindings without cloning

### DIFF
--- a/crates/prosto_derive/src/emit_proto.rs
+++ b/crates/prosto_derive/src/emit_proto.rs
@@ -450,4 +450,31 @@ mod tests {
         let proto = generate_tuple_struct_proto("Wrapper", &fields.unnamed);
         assert!(proto.contains("repeated uint64 field_0 = 1;"));
     }
+
+    #[test]
+    fn atomic_types_render_as_scalars() {
+        let fields: syn::FieldsNamed = parse_quote!({
+            f1: core::sync::atomic::AtomicBool,
+            f2: core::sync::atomic::AtomicU8,
+            f3: core::sync::atomic::AtomicU16,
+            f4: core::sync::atomic::AtomicU32,
+            f5: core::sync::atomic::AtomicU64,
+            f6: core::sync::atomic::AtomicI8,
+            f7: core::sync::atomic::AtomicI16,
+            f8: core::sync::atomic::AtomicI32,
+            f9: core::sync::atomic::AtomicI64,
+        });
+
+        let proto = generate_named_struct_proto("AtomicWrapper", &fields.named);
+
+        assert!(proto.contains("bool f1 = 1;"));
+        assert!(proto.contains("uint32 f2 = 2;"));
+        assert!(proto.contains("uint32 f3 = 3;"));
+        assert!(proto.contains("uint32 f4 = 4;"));
+        assert!(proto.contains("uint64 f5 = 5;"));
+        assert!(proto.contains("int32 f6 = 6;"));
+        assert!(proto.contains("int32 f7 = 7;"));
+        assert!(proto.contains("int32 f8 = 8;"));
+        assert!(proto.contains("int64 f9 = 9;"));
+    }
 }

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::Attribute;
@@ -13,6 +14,7 @@ use syn::spanned::Spanned;
 
 use crate::utils::FieldConfig;
 use crate::utils::ParsedFieldType;
+use crate::utils::is_atomic_type;
 use crate::utils::is_option_type;
 
 #[derive(Clone)]
@@ -238,7 +240,9 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
         }
     } else {
         let init_expr = if is_option_type(&field.field.ty) {
-            if field.parsed.is_numeric_scalar || is_value_encode_type(&field.parsed.elem_type) {
+            if is_atomic_type(&field.parsed.elem_type) && field.parsed.is_numeric_scalar {
+                quote! { (#access_expr).as_ref().map(|atomic| atomic.load(::core::sync::atomic::Ordering::Relaxed)) }
+            } else if field.parsed.is_numeric_scalar || is_value_encode_type(&field.parsed.elem_type) {
                 quote! { (#access_expr).clone() }
             } else {
                 quote! { (#access_expr).as_ref().map(|inner| inner) }
@@ -543,5 +547,35 @@ mod tests {
         assert!(binding.prelude.is_none());
         let rendered = binding.value.to_string();
         assert!(rendered.contains("Borrow :: borrow"), "binding should borrow before copying: {rendered}");
+    }
+
+    #[test]
+    fn optional_atomic_field_loads_instead_of_cloning() {
+        let field: Field = syn::parse_quote! {
+            #[proto(tag = 1)]
+            value: Option<core::sync::atomic::AtomicU32>
+        };
+
+        let config = parse_field_config(&field);
+        let parsed = parse_field_type(&field.ty);
+        let proto_ty = compute_proto_ty(&field, &config, &parsed);
+        let decode_ty = compute_decode_ty(&field, &config, &parsed, &proto_ty);
+
+        let info = FieldInfo {
+            index: 0,
+            field: &field,
+            access: FieldAccess::Named(&Ident::new("value", Span::call_site())),
+            config,
+            tag: Some(1),
+            parsed,
+            proto_ty,
+            decode_ty,
+        };
+
+        let binding = encode_input_binding(&info, &quote! { self });
+        let rendered = binding.value.to_string();
+        assert!(rendered.contains("load"), "binding should load atomic values: {rendered}");
+        assert!(rendered.contains("as_ref"), "binding should avoid cloning atomics: {rendered}");
+        assert!(!rendered.contains("clone"), "binding should not clone atomics: {rendered}");
     }
 }

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -20,6 +20,7 @@ pub use type_info::ParsedFieldType;
 pub use type_info::SetKind;
 pub use type_info::is_bytes_array;
 pub use type_info::is_bytes_vec;
+pub use type_info::is_atomic_type;
 pub use type_info::parse_field_type;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/prosto_derive/src/utils/type_info.rs
+++ b/crates/prosto_derive/src/utils/type_info.rs
@@ -79,6 +79,14 @@ pub fn parse_field_type(ty: &Type) -> ParsedFieldType {
     }
 }
 
+pub fn is_atomic_type(ty: &Type) -> bool {
+    matches!(ty, Type::Path(path) if last_ident(path).is_some_and(|id| matches!(id.to_string().as_str(),
+        "AtomicBool" |
+        "AtomicU8" | "AtomicU16" | "AtomicU32" | "AtomicU64" | "AtomicUsize" |
+        "AtomicI8" | "AtomicI16" | "AtomicI32" | "AtomicI64" | "AtomicIsize"
+    )))
+}
+
 /// True if the type is `[u8; N]`.
 pub fn is_bytes_array(ty: &Type) -> bool {
     match ty {
@@ -253,6 +261,11 @@ fn parse_primitive_or_custom(ty: &Type) -> ParsedFieldType {
                     "u64" | "usize" => numeric_scalar(ty.clone(), parse_quote! { u64 }, "uint64"),
                     "i8" | "i16" | "i32" => numeric_scalar(ty.clone(), parse_quote! { i32 }, "int32"),
                     "i64" | "isize" => numeric_scalar(ty.clone(), parse_quote! { i64 }, "int64"),
+                    "AtomicBool" => numeric_scalar(ty.clone(), parse_quote! { bool }, "bool"),
+                    "AtomicU8" | "AtomicU16" | "AtomicU32" => numeric_scalar(ty.clone(), parse_quote! { u32 }, "uint32"),
+                    "AtomicU64" | "AtomicUsize" => numeric_scalar(ty.clone(), parse_quote! { u64 }, "uint64"),
+                    "AtomicI8" | "AtomicI16" | "AtomicI32" => numeric_scalar(ty.clone(), parse_quote! { i32 }, "int32"),
+                    "AtomicI64" | "AtomicIsize" => numeric_scalar(ty.clone(), parse_quote! { i64 }, "int64"),
                     "f32" => ParsedFieldType::new(ty.clone(), "float", quote! { float }, false, true, parse_quote! { f32 }, ty.clone(), false),
                     "f64" => ParsedFieldType::new(ty.clone(), "double", quote! { double }, false, true, parse_quote! { f64 }, ty.clone(), false),
                     "bool" => numeric_scalar(ty.clone(), parse_quote! { bool }, "bool"),


### PR DESCRIPTION
## Summary
- add atomic type detection helper for reuse across codegen
- avoid cloning optional atomic fields by loading values before encoding
- cover optional atomic encoding path with a dedicated unit test

## Testing
- cargo test optional_atomic_field_loads_instead_of_cloning --package prosto_derive -- --nocapture

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d06d546888321952d5a8635dac1c3)