### PR TITLE
Handle optional atomic fields without cloning

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -172,11 +172,7 @@ impl UnifiedProtoConfig {
         let by_ref = is_reference_sun(&ty);
         let ty = normalize_sun_type(ty);
         let message_ident = extract_type_ident(&ty).expect("sun attribute expects a type path");
-        self.suns.push(SunConfig {
-            ty,
-            message_ident,
-            by_ref,
-        });
+        self.suns.push(SunConfig { ty, message_ident, by_ref });
     }
 }
 


### PR DESCRIPTION
## Summary
- treat optional atomic and atomic-like fields as borrowed values during encode binding to avoid clone requirements
- add helper utilities and tests for atomic-like detection
- apply formatting cleanup

## Testing
- cargo test --all-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d406df4508321a47fe39b2311c72c)