### PR TITLE
Avoid cloning optional non-value numeric fields

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -172,11 +172,7 @@ impl UnifiedProtoConfig {
         let by_ref = is_reference_sun(&ty);
         let ty = normalize_sun_type(ty);
         let message_ident = extract_type_ident(&ty).expect("sun attribute expects a type path");
-        self.suns.push(SunConfig {
-            ty,
-            message_ident,
-            by_ref,
-        });
+        self.suns.push(SunConfig { ty, message_ident, by_ref });
     }
 }
 

--- a/crates/prosto_derive/src/proto_message/unified_field_handler.rs
+++ b/crates/prosto_derive/src/proto_message/unified_field_handler.rs
@@ -238,7 +238,7 @@ pub fn encode_input_binding(field: &FieldInfo<'_>, base: &TokenStream2) -> Encod
         }
     } else {
         let init_expr = if is_option_type(&field.field.ty) {
-            if field.parsed.is_numeric_scalar || is_value_encode_type(&field.parsed.elem_type) {
+            if is_value_encode_type(&field.parsed.elem_type) {
                 quote! { (#access_expr).clone() }
             } else {
                 quote! { (#access_expr).as_ref().map(|inner| inner) }


### PR DESCRIPTION
## Summary
- avoid cloning optional numeric fields whose element types are not value-encoded, preventing optional atomics from requiring `Clone`
- minor formatting cleanup in the derive parser

## Testing
- cargo test --all-features

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d406df4508321a47fe39b2311c72c)