### PR TITLE
Fix complex enum default detection

### DIFF
--- a/tests/encoding_roundtrip.rs
+++ b/tests/encoding_roundtrip.rs
@@ -735,3 +735,36 @@ fn map_default_entries_align_with_prost() {
     let roundtrip = CollectionsMessage::decode(Bytes::from(proto_bytes)).expect("decode proto message");
     assert_eq!(roundtrip, message, "default map entries should survive encode/decode");
 }
+
+#[proto_message(proto_path = "protos/showcase_proto/show.proto")]
+#[derive(Clone, Debug, PartialEq)]
+enum QuoteLamports {
+    Lamports(u64),
+    WSol(u64),
+    Usdc(u64),
+    Usdt(u64),
+}
+
+#[proto_message(proto_path = "protos/showcase_proto/show.proto")]
+#[derive(Clone, Debug, PartialEq)]
+enum PaymentMethod {
+    Cash(u64),
+    Card(String),
+    Crypto(QuoteLamports),
+}
+
+#[test]
+fn complex_enum_is_default_checks_variant_and_fields() {
+    let default_method = PaymentMethod::proto_default();
+    assert!(<PaymentMethod as ProtoWire>::is_default_impl(&&default_method));
+
+    let non_default_variant = PaymentMethod::Card(String::new());
+    assert!(!<PaymentMethod as ProtoWire>::is_default_impl(&&non_default_variant));
+
+    let non_default_field = PaymentMethod::Cash(5);
+    assert!(!<PaymentMethod as ProtoWire>::is_default_impl(&&non_default_field));
+
+    let nested_default = PaymentMethod::Crypto(QuoteLamports::proto_default());
+    assert!(matches!(nested_default, PaymentMethod::Crypto(_)));
+    assert!(!<PaymentMethod as ProtoWire>::is_default_impl(&&nested_default));
+}


### PR DESCRIPTION
## Summary
- update complex enum default detection to inspect the default variant and inner fields
- add regression test covering PaymentMethod complex enum defaults

## Testing
- cargo test complex_enum_is_default_checks_variant_and_fields --tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4663b48083219c89604ffbab9af7)