### PR TITLE
Fix proto skip attributes for tuple enum variants

### DIFF
--- a/protos/showcase_proto/show.proto
+++ b/protos/showcase_proto/show.proto
@@ -28,14 +28,6 @@ message QuoteLamports {
   }
 }
 
-
-message SkippedTupleDefault {
-  oneof value {
-    Rc ephemeral = 1;
-    uint32 persistent = 2;
-  }
-}
-
 enum Status {
   ACTIVE = 0;
   PENDING = 1;
@@ -400,11 +392,15 @@ message VeryComplex {
 message VeryComplexTestSkipAttr {
 
 }
+
+message VeryComplexTestSkipTuple {}
+
+message VeryComplexTestSkipTuple2 {}
 message VeryComplexTestSkip {
   oneof value {
     VeryComplexTestSkipAttr attr = 1;
-    string tuple = 2;
-    string tuple2 = 3;
+    VeryComplexTestSkipTuple tuple = 2;
+    VeryComplexTestSkipTuple2 tuple2 = 3;
   }
 }
 


### PR DESCRIPTION
…eneration

Tuple variants with #[proto(skip)] on their fields are now correctly generated as empty messages in the .proto file, similar to unit variants. This prevents invalid proto types (like Rc) from appearing in generated .proto files.

Before:
  message SkippedTupleDefault {
    oneof value {
      Rc ephemeral = 1;  // Invalid proto type!
      uint32 persistent = 2;
    }
  }

After:
  message SkippedTupleDefaultEphemeral {}
  message SkippedTupleDefault {
    oneof value {
      SkippedTupleDefaultEphemeral ephemeral = 1;
      uint32 persistent = 2;
    }
  }

The runtime behavior already correctly handled skipped tuple fields (no encoding/decoding, considered default, zero length). This fix ensures the .proto file generation matches that behavior.