### PR TITLE
Improve transparent proto message syntax

### DIFF
--- a/crates/prosto_derive/src/proto_message/structs.rs
+++ b/crates/prosto_derive/src/proto_message/structs.rs
@@ -79,10 +79,10 @@ pub(super) fn generate_struct_impl(input: &DeriveInput, item_struct: &ItemStruct
         syn::Fields::Unit => Vec::new(),
     };
 
-    if let Some(idx) = fields.iter().position(|info| info.config.is_transparent) {
-        assert!(fields.len() == 1, "#[proto(transparent)] requires a single-field struct");
+    if config.transparent {
+        assert!(fields.len() == 1, "#[proto_message(transparent)] requires a single-field struct");
 
-        let field = fields.remove(idx);
+        let field = fields.remove(0);
         let proto_shadow_impl = generate_proto_shadow_impl(name, generics);
         let transparent_impl = generate_transparent_struct_impl(name, &impl_generics, &ty_generics, where_clause, &field, &data.fields);
 

--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -91,7 +91,6 @@ pub struct FieldConfig {
     pub is_proto_enum: bool,           // prost-like enum (i32 backing)
     pub import_path: Option<String>,
     pub custom_tag: Option<usize>,
-    pub is_transparent: bool,
     pub rename: Option<ProtoRename>,
 }
 
@@ -127,7 +126,6 @@ pub fn parse_field_config(field: &Field) -> FieldConfig {
                 Some("treat_as") => cfg.treat_as = parse_string_value(&meta),
                 Some("import_path") => cfg.import_path = parse_string_value(&meta),
                 Some("tag") => cfg.custom_tag = parse_usize_value(&meta),
-                Some("transparent") => cfg.is_transparent = true,
                 Some("rename") => {
                     let tokens: TokenStream = meta.value().expect("rename expects a value").parse().expect("failed to parse rename attribute");
                     cfg.rename = Some(parse_proto_rename(field, tokens));

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -4,14 +4,13 @@ use proto_rs::encoding::DecodeContext;
 use proto_rs::encoding::WireType;
 use proto_rs::proto_message;
 
-#[proto_message]
+#[proto_message(transparent)]
 #[derive(Debug, PartialEq, Eq)]
-pub struct UserIdTuple(#[proto(transparent)] u64);
+pub struct UserIdTuple(u64);
 
-#[proto_message]
+#[proto_message(transparent)]
 #[derive(Debug, PartialEq, Eq)]
 pub struct UserIdNamed {
-    #[proto(transparent)]
     pub id: u64,
 }
 
@@ -56,9 +55,9 @@ pub struct InnerMessage {
     pub value: u32,
 }
 
-#[proto_message]
+#[proto_message(transparent)]
 #[derive(Debug, PartialEq, Eq)]
-pub struct MessageWrapper(#[proto(transparent)] InnerMessage);
+pub struct MessageWrapper(InnerMessage);
 
 #[test]
 fn transparent_tuple_roundtrip() {


### PR DESCRIPTION
Changes:
- Move transparent attribute from field level to struct level
  - Old: #[proto_message] pub struct Foo(#[proto(transparent)] u64);
  - New: #[proto_message(transparent)] pub struct Foo(u64);
- Remove default proto_path ("protos/generated.proto")
- Skip proto file generation and build-schemas when proto_path not specified
- Update transparent tests to use new syntax

This provides a cleaner, more intuitive API for transparent types and allows users to opt-out of proto file generation when not needed.