### PR TITLE
Add sync proto_rpc method support

### DIFF
--- a/crates/prosto_derive/src/utils.rs
+++ b/crates/prosto_derive/src/utils.rs
@@ -404,6 +404,7 @@ pub struct MethodInfo {
     pub response_type: Type,
     pub response_return_type: Type,
     pub response_is_result: bool,
+    pub is_async: bool,
     pub is_streaming: bool,
     pub stream_type_name: Option<syn::Ident>,
     pub inner_response_type: Option<Type>,


### PR DESCRIPTION
## Summary
- track whether proto_rpc methods are async and preserve synchronous return signatures in the generated traits
- adjust server generation to call synchronous handlers without awaiting while still supporting async methods
- extend proto_rpc parsing tests to cover synchronous RPC handlers

## Testing
- cargo test -p prosto_derive --tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692faba5302883219df25254350de17c)