### PR TITLE
Add import-all support for proto_rpc proto generation

### DIFF
--- a/crates/prosto_derive/src/proto_dump.rs
+++ b/crates/prosto_derive/src/proto_dump.rs
@@ -59,7 +59,12 @@ fn trait_service(mut input: ItemTrait, mut config: UnifiedProtoConfig) -> TokenS
     let proto_name = input.ident.to_string();
     let clean_name = proto_name.strip_suffix("Proto").unwrap_or(&proto_name);
     let (methods, _) = extract_methods_and_types(&input);
-    let proto_def = generate_service_content(&input.ident, &methods, &config.type_imports);
+    let proto_def = generate_service_content(
+        &input.ident,
+        &methods,
+        &config.type_imports,
+        config.import_all_from.as_deref(),
+    );
     config.register_and_emit_proto(clean_name, &proto_def);
     strip_proto_attributes_from_trait(&mut input);
     let proto = config.imports_mat;

--- a/crates/prosto_derive/src/proto_rpc.rs
+++ b/crates/prosto_derive/src/proto_rpc.rs
@@ -27,7 +27,12 @@ pub fn proto_rpc_impl(args: TokenStream, item: TokenStream) -> TokenStream2 {
     let (methods, user_associated_types) = extract_methods_and_types(&input);
 
     // Generate .proto file if requested
-    let service_content = generate_service_content(trait_name, &methods, &config.type_imports);
+    let service_content = generate_service_content(
+        trait_name,
+        &methods,
+        &config.type_imports,
+        config.import_all_from.as_deref(),
+    );
     config.register_and_emit_proto(&ty_ident, &service_content);
     let proto = config.imports_mat.clone();
 


### PR DESCRIPTION
## Summary
- add `proto_import_all_from` attribute parsing and registration for proto RPC traits
- qualify generated service types using the default import-all package unless explicitly overridden
- cover the new behavior with a unit test for service content generation

## Testing
- cargo test qualify_type_name_falls_back_to_import_all_from --package prosto_derive


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd49ce29083218953e9e0eba358ac)