### PR TITLE
Improve papaya HashSet support

### DIFF
--- a/protos/tests/papaya.proto
+++ b/protos/tests/papaya.proto
@@ -12,3 +12,11 @@ message PapayaCustomCollections {
   repeated uint32 flags = 2;
 }
 
+message PapayaStringSet {
+  repeated string tags = 1;
+}
+
+message PapayaCustomStringSet {
+  repeated string tags = 1;
+}
+

--- a/tests/papaya_roundtrip.rs
+++ b/tests/papaya_roundtrip.rs
@@ -41,6 +41,20 @@ pub struct PapayaCustomCollections {
     pub flags: papaya::HashSet<u32, IdentityBuildHasher>,
 }
 
+#[proto_message(proto_path = "protos/tests/papaya.proto")]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PapayaStringSet {
+    #[proto(tag = 1)]
+    pub tags: papaya::HashSet<String>,
+}
+
+#[proto_message(proto_path = "protos/tests/papaya.proto")]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PapayaCustomStringSet {
+    #[proto(tag = 1)]
+    pub tags: papaya::HashSet<String, IdentityBuildHasher>,
+}
+
 #[test]
 fn papaya_hash_collections_roundtrip() {
     let message = PapayaCollections::default();
@@ -90,6 +104,43 @@ fn papaya_hash_collections_support_custom_hashers() {
 
     let encoded = PapayaCustomCollections::encode_to_vec(&message);
     let decoded = PapayaCustomCollections::decode(&encoded[..]).expect("decode papaya custom collections");
+
+    assert_eq!(decoded, message);
+}
+
+#[test]
+fn papaya_hashset_roundtrip_with_strings() {
+    let message = PapayaStringSet::default();
+
+    {
+        let guard = message.tags.pin();
+        guard.insert("red".to_string());
+        guard.insert("green".to_string());
+        guard.insert("blue".to_string());
+    }
+
+    let encoded = PapayaStringSet::encode_to_vec(&message);
+    let decoded = PapayaStringSet::decode(&encoded[..]).expect("decode papaya string set");
+
+    assert_eq!(decoded, message);
+
+    let guard = decoded.tags.pin();
+    assert_eq!(guard.len(), 3);
+    assert!(guard.contains("red"));
+}
+
+#[test]
+fn papaya_hashset_roundtrip_with_custom_hasher_strings() {
+    let message = PapayaCustomStringSet::default();
+
+    {
+        let guard = message.tags.pin();
+        guard.insert("alpha".to_string());
+        guard.insert("beta".to_string());
+    }
+
+    let encoded = PapayaCustomStringSet::encode_to_vec(&message);
+    let decoded = PapayaCustomStringSet::decode(&encoded[..]).expect("decode papaya custom string set");
 
     assert_eq!(decoded, message);
 }


### PR DESCRIPTION
## Summary
- streamline papaya::HashSet ProtoWire implementation to use EncodeInputFromRef and drop duplicate copy-specific macro implementations
- extend papaya test proto schema with string-based sets for papaya collections
- add papaya::HashSet round-trip coverage for string values and custom hashers

## Testing
- cargo test --features papaya

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe544be948321ba25a20f2360b5cf)