### PR TITLE
Track transparent types in proto registry and rewrite field types

### DIFF
--- a/crates/prosto_derive/src/proto_rpc.rs
+++ b/crates/prosto_derive/src/proto_rpc.rs
@@ -14,12 +14,13 @@ use utils::extract_methods_and_types; // Add this import
 
 use crate::emit_proto::generate_service_content;
 use crate::parse::UnifiedProtoConfig;
+use crate::write_file::ProtoEntry;
 
 pub fn proto_rpc_impl(args: TokenStream, item: TokenStream) -> TokenStream2 {
     let input: ItemTrait = syn::parse(item).expect("Failed to parse trait");
     let trait_name = &input.ident;
     let ty_ident = trait_name.to_string();
-    let mut config = UnifiedProtoConfig::from_attributes(args, &ty_ident, &input.attrs, &input);
+    let mut config = UnifiedProtoConfig::from_attributes(args, &ty_ident, &input.attrs, &input, input.ident.span());
     let vis = &input.vis;
     let package_name = config.get_rpc_package().to_owned();
 
@@ -33,7 +34,7 @@ pub fn proto_rpc_impl(args: TokenStream, item: TokenStream) -> TokenStream2 {
         &config.type_imports,
         config.import_all_from.as_deref(),
     );
-    config.register_and_emit_proto(&ty_ident, &service_content);
+    config.register_and_emit_proto(&ty_ident, ProtoEntry::definition(service_content, Vec::new()));
     let proto = config.imports_mat.clone();
 
     // Generate user-facing trait

--- a/crates/prosto_derive/src/write_file.rs
+++ b/crates/prosto_derive/src/write_file.rs
@@ -16,10 +16,143 @@ use quote::quote;
 use crate::utils::derive_package_name;
 use crate::utils::format_import;
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProtoTypeId(String);
+
+impl ProtoTypeId {
+    pub fn new(crate_name: &str, module_path: &str, type_name: &str) -> Self {
+        let module_path = normalize_module_path(crate_name, module_path);
+        Self(format!("{module_path}::{type_name}"))
+    }
+
+    fn import_key(import: &str) -> Self {
+        Self(format!("{IMPORT_PREFIX}:{import}"))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TypeInfo {
+    pub transparent: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProtoFieldEntry {
+    pub type_id: ProtoTypeId,
+    pub field_name: String,
+    pub modifier: String,
+    pub tag: usize,
+    pub proto_type: String,
+    pub indent: String,
+    pub allow_rename: bool,
+    pub line: String,
+}
+
+impl ProtoFieldEntry {
+    pub fn new(
+        type_id: ProtoTypeId,
+        field_name: String,
+        modifier: String,
+        tag: usize,
+        proto_type: String,
+        indent: String,
+        allow_rename: bool,
+    ) -> Self {
+        let line = format!("{indent}{modifier}{proto_type} {field_name} = {tag};");
+        Self {
+            type_id,
+            field_name,
+            modifier,
+            tag,
+            proto_type,
+            indent,
+            allow_rename,
+            line,
+        }
+    }
+
+    fn update_proto_type(&mut self, new_proto_type: &str, content: &mut String) -> bool {
+        if !self.allow_rename || self.proto_type == new_proto_type {
+            return false;
+        }
+
+        let new_line = format!("{}{}{} {} = {};", self.indent, self.modifier, new_proto_type, self.field_name, self.tag);
+        if content.contains(&self.line) {
+            *content = content.replace(&self.line, &new_line);
+        }
+        self.proto_type = new_proto_type.to_string();
+        self.line = new_line;
+        true
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ProtoEntryKind {
+    Import,
+    Definition,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProtoEntry {
+    pub content: String,
+    pub fields: Vec<ProtoFieldEntry>,
+    pub kind: ProtoEntryKind,
+}
+
+impl ProtoEntry {
+    pub fn definition(content: String, fields: Vec<ProtoFieldEntry>) -> Self {
+        Self {
+            content,
+            fields,
+            kind: ProtoEntryKind::Definition,
+        }
+    }
+
+    pub fn import(content: String) -> Self {
+        Self {
+            content,
+            fields: Vec::new(),
+            kind: ProtoEntryKind::Import,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TypeIdContext {
+    crate_name: String,
+    module_path: String,
+}
+
+impl TypeIdContext {
+    pub fn new(span: proc_macro2::Span) -> Self {
+        let crate_name = std::env::var("CARGO_CRATE_NAME")
+            .or_else(|_| std::env::var("CARGO_PKG_NAME"))
+            .unwrap_or_else(|_| "unknown_crate".to_string());
+        let module_path = module_path_from_span(&crate_name, span).unwrap_or_else(|| crate_name.clone());
+        Self { crate_name, module_path }
+    }
+
+    pub fn proto_type_id(&self, type_name: &str) -> ProtoTypeId {
+        ProtoTypeId::new(&self.crate_name, &self.module_path, type_name)
+    }
+
+    pub fn type_id_for_type(&self, ty: &syn::Type) -> Option<ProtoTypeId> {
+        let syn::Type::Path(type_path) = ty else {
+            return None;
+        };
+
+        let segments: Vec<String> = type_path.path.segments.iter().map(|seg| seg.ident.to_string()).collect();
+        let (module_path, type_name) = resolve_module_and_type(&self.crate_name, &self.module_path, &segments)?;
+        Some(ProtoTypeId::new(&self.crate_name, &module_path, type_name))
+    }
+}
+
 const IMPORT_PREFIX: &str = "__IMPORT__";
 
-/// Global registry: filename -> `BTreeSet`<proto definitions>
-static REGISTRY: LazyLock<Mutex<HashMap<String, BTreeSet<String>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+/// Global registry: filename -> `BTreeMap`<ProtoTypeId, ProtoEntry>
+static REGISTRY: LazyLock<Mutex<HashMap<String, BTreeMap<ProtoTypeId, ProtoEntry>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Type registry: proto type id -> type info
+static TYPE_REGISTRY: LazyLock<Mutex<HashMap<ProtoTypeId, TypeInfo>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Track initialized files
 static INITIALIZED_FILES: LazyLock<Mutex<BTreeSet<String>>> = LazyLock::new(|| Mutex::new(BTreeSet::new()));
@@ -58,14 +191,43 @@ fn format_const_name(file_name: &str, type_ident: &str) -> String {
 }
 
 /// Register proto content and optionally write to file
-pub fn register_and_emit_proto_inner(file_name: &str, type_ident: &str, content: &str) -> TokenStream {
-    let emission_code = generate_proto_emission(file_name, type_ident, content);
+pub fn register_and_emit_proto_inner(file_name: &str, type_ident: &str, type_id: ProtoTypeId, entry: ProtoEntry) -> TokenStream {
+    let emission_code = generate_proto_emission(file_name, type_ident, &entry.content);
 
-    if should_emit_file() {
-        write_proto_file(file_name, content);
+    let updated = register_proto_entry(file_name, type_id, entry);
+
+    if updated && should_emit_file() {
+        write_proto_file_internal(file_name);
     }
 
     emission_code
+}
+
+pub fn register_type_info(type_id: ProtoTypeId, type_info: TypeInfo) {
+    let mut registry = TYPE_REGISTRY.lock().unwrap();
+    registry.insert(type_id, type_info);
+    drop(registry);
+
+    let mut updated_files = Vec::new();
+    {
+        let type_registry = TYPE_REGISTRY.lock().unwrap();
+        let mut proto_registry = REGISTRY.lock().unwrap();
+        for (file_name, entries) in proto_registry.iter_mut() {
+            let mut updated = false;
+            for entry in entries.values_mut() {
+                updated |= apply_type_registry_to_entry(entry, &type_registry);
+            }
+            if updated {
+                updated_files.push(file_name.clone());
+            }
+        }
+    }
+
+    if should_emit_file() {
+        for file in updated_files {
+            write_proto_file_internal(&file);
+        }
+    }
 }
 
 /// Register imports for a proto file
@@ -97,8 +259,8 @@ fn register_imports_in_registry(file: &str, imports: &BTreeSet<String>) {
     let defs = registry.entry(file.to_string()).or_default();
 
     for import in imports {
-        let import_entry = format!("{IMPORT_PREFIX}:{import}");
-        defs.insert(import_entry);
+        let import_entry = ProtoEntry::import(format!("{IMPORT_PREFIX}:{import}"));
+        defs.insert(ProtoTypeId::import_key(import), import_entry);
     }
 }
 
@@ -112,8 +274,8 @@ pub fn register_import(file: &str, imports: &[String]) -> TokenStream {
 
         for import in imports {
             content.push_str(&format_import(import));
-            let import_entry = format!("{IMPORT_PREFIX}:{import}");
-            defs.insert(import_entry);
+            let import_entry = ProtoEntry::import(format!("{IMPORT_PREFIX}:{import}"));
+            defs.insert(ProtoTypeId::import_key(import), import_entry);
         }
     }
 
@@ -127,15 +289,15 @@ pub fn register_import(file: &str, imports: &[String]) -> TokenStream {
 }
 
 /// Write proto content to registry
-fn write_proto_file(file_name_path: &str, content: &str) {
+fn register_proto_entry(file_name_path: &str, type_id: ProtoTypeId, mut entry: ProtoEntry) -> bool {
+    let type_registry = TYPE_REGISTRY.lock().unwrap();
+    apply_type_registry_to_entry(&mut entry, &type_registry);
+    drop(type_registry);
+
     let mut registry = REGISTRY.lock().unwrap();
     let defs = registry.entry(file_name_path.to_string()).or_default();
-    let was_new = defs.insert(content.to_string());
-
-    if was_new && should_emit_file() {
-        drop(registry);
-        write_proto_file_internal(file_name_path);
-    }
+    let existing = defs.insert(type_id, entry);
+    existing.is_none()
 }
 
 /// Internal file writing implementation
@@ -167,15 +329,18 @@ fn write_proto_file_internal(file_name_path: &str) {
     mark_file_initialized(file_name_path);
 }
 
-fn separate_imports_and_content(defs: &BTreeSet<String>) -> (Vec<String>, Vec<String>) {
+fn separate_imports_and_content(defs: &BTreeMap<ProtoTypeId, ProtoEntry>) -> (Vec<String>, Vec<String>) {
     let mut imports = Vec::new();
     let mut content = Vec::new();
 
-    for item in defs {
-        if let Some(import_path) = item.strip_prefix(&format!("{IMPORT_PREFIX}:")) {
-            imports.push(import_path.to_string());
-        } else {
-            content.push(item.clone());
+    for entry in defs.values() {
+        match entry.kind {
+            ProtoEntryKind::Import => {
+                if let Some(import_path) = entry.content.strip_prefix(&format!("{IMPORT_PREFIX}:")) {
+                    imports.push(import_path.to_string());
+                }
+            }
+            ProtoEntryKind::Definition => content.push(entry.content.clone()),
         }
     }
 
@@ -217,6 +382,154 @@ fn write_file_atomically(path: &Path, content: &str) {
 fn mark_file_initialized(file_name_path: &str) {
     let mut initialized = INITIALIZED_FILES.lock().unwrap();
     initialized.insert(file_name_path.to_string());
+}
+
+fn apply_type_registry_to_entry(entry: &mut ProtoEntry, type_registry: &HashMap<ProtoTypeId, TypeInfo>) -> bool {
+    let mut updated = false;
+    for field in &mut entry.fields {
+        if let Some(type_info) = type_registry.get(&field.type_id)
+            && let Some(ref transparent_type) = type_info.transparent
+        {
+            updated |= field.update_proto_type(transparent_type, &mut entry.content);
+        }
+    }
+
+    updated
+}
+
+fn normalize_module_path(crate_name: &str, module_path: &str) -> String {
+    if module_path.starts_with(crate_name) {
+        module_path.to_string()
+    } else if module_path.is_empty() {
+        crate_name.to_string()
+    } else {
+        format!("{crate_name}::{module_path}")
+    }
+}
+
+fn module_path_from_span(crate_name: &str, span: proc_macro2::Span) -> Option<String> {
+    let _ = span;
+    // Stable proc-macro spans do not expose module paths, so default to the crate root.
+    Some(crate_name.to_string())
+}
+
+fn resolve_module_and_type<'a>(crate_name: &str, module_path: &str, segments: &'a [String]) -> Option<(String, &'a str)> {
+    if segments.is_empty() {
+        return None;
+    }
+
+    let type_name = segments.last()?.as_str();
+    if segments.len() == 1 {
+        return Some((module_path.to_string(), type_name));
+    }
+
+    let (base, index) = if segments[0] == "crate" || segments[0] == crate_name {
+        (crate_name.to_string(), 1)
+    } else if segments[0] == "self" {
+        (module_path.to_string(), 1)
+    } else if segments[0] == "super" {
+        let mut up_levels = 0;
+        while segments.get(up_levels).is_some_and(|seg| seg == "super") {
+            up_levels += 1;
+        }
+        (parent_module_path(module_path, up_levels), up_levels)
+    } else {
+        (crate_name.to_string(), 0)
+    };
+
+    let module_segments = &segments[index..segments.len().saturating_sub(1)];
+    let resolved = if module_segments.is_empty() {
+        base
+    } else {
+        format!("{base}::{}", module_segments.join("::"))
+    };
+
+    Some((resolved, type_name))
+}
+
+fn parent_module_path(module_path: &str, levels: usize) -> String {
+    let mut parts: Vec<&str> = module_path.split("::").collect();
+    for _ in 0..levels {
+        if parts.len() > 1 {
+            parts.pop();
+        }
+    }
+    parts.join("::")
+}
+
+#[cfg(test)]
+fn clear_registries() {
+    REGISTRY.lock().unwrap().clear();
+    TYPE_REGISTRY.lock().unwrap().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field_entry(type_id: ProtoTypeId, proto_type: &str) -> ProtoFieldEntry {
+        ProtoFieldEntry::new(
+            type_id,
+            "id".to_string(),
+            "".to_string(),
+            1,
+            proto_type.to_string(),
+            "  ".to_string(),
+            true,
+        )
+    }
+
+    #[test]
+    fn transparent_types_rewrite_existing_entries() {
+        clear_registries();
+
+        let type_id = ProtoTypeId::new("demo", "demo::types", "UserWithId");
+        let field_type_id = ProtoTypeId::new("demo", "demo::types", "UserIdNamed");
+        let mut entry = ProtoEntry::definition(
+            "message UserWithId {\n  UserIdNamed id = 1;\n}\n\n".to_string(),
+            vec![field_entry(field_type_id.clone(), "UserIdNamed")],
+        );
+        register_proto_entry("demo.proto", type_id, entry.clone());
+
+        register_type_info(
+            field_type_id,
+            TypeInfo {
+                transparent: Some("uint64".to_string()),
+            },
+        );
+
+        let registry = REGISTRY.lock().unwrap();
+        let entries = registry.get("demo.proto").expect("entry exists");
+        let stored = entries.values().next().expect("stored entry");
+        assert!(stored.content.contains("uint64 id = 1;"));
+        assert!(!stored.content.contains("UserIdNamed id = 1;"));
+    }
+
+    #[test]
+    fn transparent_types_rewrite_new_entries_after_registration() {
+        clear_registries();
+
+        let field_type_id = ProtoTypeId::new("demo", "demo::types", "UserIdNamed");
+        register_type_info(
+            field_type_id.clone(),
+            TypeInfo {
+                transparent: Some("uint64".to_string()),
+            },
+        );
+
+        let type_id = ProtoTypeId::new("demo", "demo::types", "UserWithId");
+        let entry = ProtoEntry::definition(
+            "message UserWithId {\n  UserIdNamed id = 1;\n}\n\n".to_string(),
+            vec![field_entry(field_type_id, "UserIdNamed")],
+        );
+        register_proto_entry("demo.proto", type_id, entry);
+
+        let registry = REGISTRY.lock().unwrap();
+        let entries = registry.get("demo.proto").expect("entry exists");
+        let stored = entries.values().next().expect("stored entry");
+        assert!(stored.content.contains("uint64 id = 1;"));
+        assert!(!stored.content.contains("UserIdNamed id = 1;"));
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation

- Make transparent newtype wrappers automatically emit the inner proto type so users don't need `#[proto(rename = "...")]` on fields. 
- Allow macros to collect and apply type-level metadata (like `transparent`) across out-of-order macro invocations. 
- Replace plain string registry entries with structured metadata so entries can be updated when a type's info becomes available. 
- Preserve existing emit/write behavior while enabling automatic rewriting of previously-registered proto content.

### Description

- Replace the global `REGISTRY: HashMap<String, BTreeSet<String>>` with a structured `REGISTRY: HashMap<String, BTreeMap<ProtoTypeId, ProtoEntry>>` and add `TYPE_REGISTRY: HashMap<ProtoTypeId, TypeInfo>` to track type metadata. 
- Introduce `ProtoTypeId`, `ProtoEntry`, `ProtoFieldEntry`, and `TypeInfo` types and a `TypeIdContext` helper to compute crate-scoped type ids. 
- Change proto emitters to produce `ProtoEntry` (with per-field `ProtoFieldEntry` metadata) and to call `register_and_emit_proto_inner` with a `ProtoTypeId` and `ProtoEntry`. 
- Implement `register_type_info` which updates existing registered `ProtoEntry` values by rewriting field proto types when a type is marked `transparent`, and ensure file emission is updated accordingly. 
- Wire the new behavior into `proto_message`, `proto_rpc`, and `proto_dump` paths, and add helpers like `transparent_proto_type` and `resolve_proto_type_with_info` to compute and record renames.

### Testing

- Ran the full workspace test suite with `cargo test` and all automated tests passed. 
- Added unit tests in `crates/prosto_derive/src/write_file.rs` that exercise rewriting registered entries and registering type info before/after entry registration, and both tests passed. 
- Verified existing transparent-related tests in `tests/transparent.rs` continue to pass. 
- A benign warning about an unused example import was observed but did not affect test success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585a234e488321bb7600219635ab4b)