### PR TITLE
Handle transparent types in proto registry

### DIFF
--- a/crates/prosto_derive/src/proto_dump.rs
+++ b/crates/prosto_derive/src/proto_dump.rs
@@ -12,16 +12,19 @@ use crate::emit_proto::generate_simple_enum_proto;
 use crate::emit_proto::generate_struct_proto;
 use crate::parse::UnifiedProtoConfig;
 use crate::proto_rpc::utils::extract_methods_and_types;
+use crate::write_file::module_path_from_call_site;
 
 pub fn proto_dump_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<DeriveInput>(item.clone()) {
         let type_ident = input.ident.to_string();
-        let config = UnifiedProtoConfig::from_attributes(attr, &type_ident, &input.attrs, &input.data);
+        let module_path = module_path_from_call_site();
+        let config = UnifiedProtoConfig::from_attributes(attr, &type_ident, module_path, &input.attrs, &input.data);
         return struct_or_enum(input, config);
     }
     if let Ok(input) = syn::parse::<syn::ItemTrait>(item) {
         let type_ident = input.ident.to_string();
-        let config = UnifiedProtoConfig::from_attributes(attr, &type_ident, &input.attrs, &input);
+        let module_path = module_path_from_call_site();
+        let config = UnifiedProtoConfig::from_attributes(attr, &type_ident, module_path, &input.attrs, &input);
         return trait_service(input, config);
     }
 

--- a/crates/prosto_derive/src/proto_rpc.rs
+++ b/crates/prosto_derive/src/proto_rpc.rs
@@ -14,12 +14,14 @@ use utils::extract_methods_and_types; // Add this import
 
 use crate::emit_proto::generate_service_content;
 use crate::parse::UnifiedProtoConfig;
+use crate::write_file::module_path_from_call_site;
 
 pub fn proto_rpc_impl(args: TokenStream, item: TokenStream) -> TokenStream2 {
     let input: ItemTrait = syn::parse(item).expect("Failed to parse trait");
     let trait_name = &input.ident;
     let ty_ident = trait_name.to_string();
-    let mut config = UnifiedProtoConfig::from_attributes(args, &ty_ident, &input.attrs, &input);
+    let module_path = module_path_from_call_site();
+    let mut config = UnifiedProtoConfig::from_attributes(args, &ty_ident, module_path, &input.attrs, &input);
     let vis = &input.vis;
     let package_name = config.get_rpc_package().to_owned();
 

--- a/crates/prosto_derive/src/write_file.rs
+++ b/crates/prosto_derive/src/write_file.rs
@@ -18,8 +18,92 @@ use crate::utils::format_import;
 
 const IMPORT_PREFIX: &str = "__IMPORT__";
 
-/// Global registry: filename -> `BTreeSet`<proto definitions>
-static REGISTRY: LazyLock<Mutex<HashMap<String, BTreeSet<String>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProtoTypeId {
+    crate_name: String,
+    module_path: String,
+    type_name: String,
+    proto_name: Option<String>,
+}
+
+impl ProtoTypeId {
+    pub fn for_type(module_path: &str, type_name: &str) -> Self {
+        Self::new(module_path, type_name, None)
+    }
+
+    pub fn for_definition(module_path: &str, type_name: &str, proto_name: &str) -> Self {
+        let proto_name = (proto_name != type_name).then_some(proto_name.to_string());
+        Self::new(module_path, type_name, proto_name)
+    }
+
+    fn for_import(import: &str) -> Self {
+        Self::new("import", IMPORT_PREFIX, Some(import.to_string()))
+    }
+
+    fn new(module_path: &str, type_name: &str, proto_name: Option<String>) -> Self {
+        let crate_name = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "unknown_crate".to_string());
+        Self {
+            crate_name,
+            module_path: module_path.to_string(),
+            type_name: type_name.to_string(),
+            proto_name,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeInfo {
+    pub type_name: String,
+    pub transparent: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ProtoEntry {
+    raw_content: String,
+    content: String,
+    is_import: bool,
+}
+
+impl ProtoEntry {
+    fn new_definition(content: &str, type_registry: &HashMap<ProtoTypeId, TypeInfo>) -> Self {
+        let raw_content = content.to_string();
+        let content = rewrite_proto_content(&raw_content, type_registry);
+        Self {
+            raw_content,
+            content,
+            is_import: false,
+        }
+    }
+
+    fn new_import(import: &str) -> Self {
+        Self {
+            raw_content: import.to_string(),
+            content: import.to_string(),
+            is_import: true,
+        }
+    }
+
+    fn update_raw_content(&mut self, content: &str, type_registry: &HashMap<ProtoTypeId, TypeInfo>) -> bool {
+        if self.raw_content == content {
+            return false;
+        }
+        self.raw_content = content.to_string();
+        self.content = rewrite_proto_content(&self.raw_content, type_registry);
+        true
+    }
+
+    fn refresh_content(&mut self, type_registry: &HashMap<ProtoTypeId, TypeInfo>) {
+        if !self.is_import {
+            self.content = rewrite_proto_content(&self.raw_content, type_registry);
+        }
+    }
+}
+
+/// Global registry: filename -> `BTreeMap`<proto definitions>
+static REGISTRY: LazyLock<Mutex<HashMap<String, BTreeMap<ProtoTypeId, ProtoEntry>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static TYPE_REGISTRY: LazyLock<Mutex<HashMap<ProtoTypeId, TypeInfo>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Track initialized files
 static INITIALIZED_FILES: LazyLock<Mutex<BTreeSet<String>>> = LazyLock::new(|| Mutex::new(BTreeSet::new()));
@@ -31,6 +115,22 @@ pub fn should_emit_file() -> bool {
         Some("0" | "false" | "False" | "FALSE") => false,
         Some("1" | "true" | "True" | "TRUE") => true,
         _ => cfg!(feature = "emit-proto-files"),
+    }
+}
+
+pub fn module_path_from_call_site() -> String {
+    module_path!().to_string()
+}
+
+pub fn register_type_info(proto_type_id: ProtoTypeId, info: TypeInfo) {
+    let mut type_registry = TYPE_REGISTRY.lock().unwrap();
+    type_registry.insert(proto_type_id, info);
+
+    let mut registry = REGISTRY.lock().unwrap();
+    for entries in registry.values_mut() {
+        for entry in entries.values_mut() {
+            entry.refresh_content(&type_registry);
+        }
     }
 }
 
@@ -58,11 +158,11 @@ fn format_const_name(file_name: &str, type_ident: &str) -> String {
 }
 
 /// Register proto content and optionally write to file
-pub fn register_and_emit_proto_inner(file_name: &str, type_ident: &str, content: &str) -> TokenStream {
+pub fn register_and_emit_proto_inner(file_name: &str, type_ident: &str, proto_type_id: ProtoTypeId, content: &str) -> TokenStream {
     let emission_code = generate_proto_emission(file_name, type_ident, content);
 
     if should_emit_file() {
-        write_proto_file(file_name, content);
+        write_proto_file(file_name, proto_type_id, content);
     }
 
     emission_code
@@ -97,8 +197,7 @@ fn register_imports_in_registry(file: &str, imports: &BTreeSet<String>) {
     let defs = registry.entry(file.to_string()).or_default();
 
     for import in imports {
-        let import_entry = format!("{IMPORT_PREFIX}:{import}");
-        defs.insert(import_entry);
+        defs.entry(ProtoTypeId::for_import(import)).or_insert_with(|| ProtoEntry::new_import(import));
     }
 }
 
@@ -112,8 +211,7 @@ pub fn register_import(file: &str, imports: &[String]) -> TokenStream {
 
         for import in imports {
             content.push_str(&format_import(import));
-            let import_entry = format!("{IMPORT_PREFIX}:{import}");
-            defs.insert(import_entry);
+            defs.entry(ProtoTypeId::for_import(import)).or_insert_with(|| ProtoEntry::new_import(import));
         }
     }
 
@@ -127,10 +225,17 @@ pub fn register_import(file: &str, imports: &[String]) -> TokenStream {
 }
 
 /// Write proto content to registry
-fn write_proto_file(file_name_path: &str, content: &str) {
+fn write_proto_file(file_name_path: &str, proto_type_id: ProtoTypeId, content: &str) {
+    let type_registry = TYPE_REGISTRY.lock().unwrap();
     let mut registry = REGISTRY.lock().unwrap();
     let defs = registry.entry(file_name_path.to_string()).or_default();
-    let was_new = defs.insert(content.to_string());
+    let was_new = match defs.get_mut(&proto_type_id) {
+        Some(entry) => entry.update_raw_content(content, &type_registry),
+        None => {
+            defs.insert(proto_type_id, ProtoEntry::new_definition(content, &type_registry));
+            true
+        }
+    };
 
     if was_new && should_emit_file() {
         drop(registry);
@@ -167,15 +272,15 @@ fn write_proto_file_internal(file_name_path: &str) {
     mark_file_initialized(file_name_path);
 }
 
-fn separate_imports_and_content(defs: &BTreeSet<String>) -> (Vec<String>, Vec<String>) {
+fn separate_imports_and_content(defs: &BTreeMap<ProtoTypeId, ProtoEntry>) -> (Vec<String>, Vec<String>) {
     let mut imports = Vec::new();
     let mut content = Vec::new();
 
-    for item in defs {
-        if let Some(import_path) = item.strip_prefix(&format!("{IMPORT_PREFIX}:")) {
-            imports.push(import_path.to_string());
+    for entry in defs.values() {
+        if entry.is_import {
+            imports.push(entry.content.clone());
         } else {
-            content.push(item.clone());
+            content.push(entry.content.clone());
         }
     }
 
@@ -219,12 +324,102 @@ fn mark_file_initialized(file_name_path: &str) {
     initialized.insert(file_name_path.to_string());
 }
 
+fn rewrite_proto_content(content: &str, type_registry: &HashMap<ProtoTypeId, TypeInfo>) -> String {
+    let replacements: HashMap<&str, &str> = type_registry
+        .values()
+        .filter_map(|info| info.transparent.as_deref().map(|transparent| (info.type_name.as_str(), transparent)))
+        .collect();
+
+    if replacements.is_empty() {
+        return content.to_string();
+    }
+
+    let mut output = String::with_capacity(content.len());
+    for line in content.split_inclusive('\n') {
+        let (line_body, line_ending) = line.split_at(line.len().saturating_sub(line.ends_with('\n') as usize));
+        let rewritten = rewrite_proto_line(line_body, &replacements);
+        output.push_str(&rewritten);
+        output.push_str(line_ending);
+    }
+
+    output
+}
+
+fn rewrite_proto_line(line: &str, replacements: &HashMap<&str, &str>) -> String {
+    let trimmed = line.trim();
+    if !trimmed.ends_with(';') || !trimmed.contains('=') {
+        return line.to_string();
+    }
+
+    let Some(trimmed_no_semi) = trimmed.strip_suffix(';') else {
+        return line.to_string();
+    };
+
+    let Some((lhs, rhs)) = trimmed_no_semi.split_once('=') else {
+        return line.to_string();
+    };
+
+    let tokens: Vec<&str> = lhs.split_whitespace().collect();
+    if tokens.len() < 2 {
+        return line.to_string();
+    }
+
+    let field_name = tokens[tokens.len() - 1];
+    let mut type_tokens = &tokens[..tokens.len() - 1];
+    let mut modifier = "";
+
+    if let Some(first) = type_tokens.first()
+        && (*first == "optional" || *first == "repeated")
+    {
+        modifier = first;
+        type_tokens = &type_tokens[1..];
+    }
+
+    if type_tokens.is_empty() {
+        return line.to_string();
+    }
+
+    let type_value = type_tokens.join(" ");
+    let updated_type = rewrite_type_value(&type_value, replacements);
+
+    let prefix_len = line.len() - line.trim_start().len();
+    let prefix = &line[..prefix_len];
+
+    let rhs_trim = rhs.trim();
+    if modifier.is_empty() {
+        format!("{prefix}{updated_type} {field_name} = {rhs_trim};")
+    } else {
+        format!("{prefix}{modifier} {updated_type} {field_name} = {rhs_trim};")
+    }
+}
+
+fn rewrite_type_value(type_value: &str, replacements: &HashMap<&str, &str>) -> String {
+    if let Some(replacement) = replacements.get(type_value) {
+        return (*replacement).to_string();
+    }
+
+    if let Some(inner) = type_value.strip_prefix("map<").and_then(|value| value.strip_suffix('>')) {
+        let mut parts = inner.split(',').map(|part| part.trim()).collect::<Vec<_>>();
+        if parts.len() == 2 {
+            if let Some(replacement) = replacements.get(parts[1]) {
+                parts[1] = replacement;
+            }
+            return format!("map<{}, {}>", parts[0], parts[1]);
+        }
+    }
+
+    type_value.to_string()
+}
+
 // ============================================================================
 // TESTS
 // ============================================================================
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -235,10 +430,13 @@ mod tests {
 
     #[test]
     fn test_separate_imports_and_content() {
-        let mut defs = BTreeSet::new();
-        defs.insert("__IMPORT__:common/types".to_string());
-        defs.insert("message Foo {}".to_string());
-        defs.insert("__IMPORT__:other/service".to_string());
+        let mut defs = BTreeMap::new();
+        defs.insert(ProtoTypeId::for_import("common/types"), ProtoEntry::new_import("common/types"));
+        defs.insert(
+            ProtoTypeId::for_definition("crate", "Foo", "Foo"),
+            ProtoEntry::new_definition("message Foo {}", &HashMap::new()),
+        );
+        defs.insert(ProtoTypeId::for_import("other/service"), ProtoEntry::new_import("other/service"));
 
         let (imports, content) = separate_imports_and_content(&defs);
 
@@ -248,6 +446,32 @@ mod tests {
 
         assert_eq!(content.len(), 1);
         assert_eq!(content[0], "message Foo {}");
+    }
+
+    #[test]
+    fn rewrites_transparent_types_in_proto_fields() {
+        let mut type_registry = HashMap::new();
+        type_registry.insert(
+            ProtoTypeId::for_type("crate::types", "UserIdNamed"),
+            TypeInfo {
+                type_name: "UserIdNamed".to_string(),
+                transparent: Some("uint64".to_string()),
+            },
+        );
+
+        let content = "\
+message UserWithId {
+  UserIdNamed id = 1;
+  optional UserIdNamed opt = 2;
+  map<uint32, UserIdNamed> ids = 3;
+}
+";
+
+        let rewritten = rewrite_proto_content(content, &type_registry);
+
+        assert!(rewritten.contains("uint64 id = 1;"));
+        assert!(rewritten.contains("optional uint64 opt = 2;"));
+        assert!(rewritten.contains("map<uint32, uint64> ids = 3;"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Improve ergonomics for `#[proto_message(transparent)]` so user code does not require manual `#[proto(rename = "...")]` on fields referring to transparent types.
- Ensure proto generation rewrites field types consistently when transparent types are defined in any order across macro expansions.
- Centralize proto registry data so macros can update previously generated proto entries when type metadata (like transparency) becomes known.

### Description

- Replace the simple `REGISTRY: HashMap<String, BTreeSet<String>>` with a typed registry `HashMap<String, BTreeMap<ProtoTypeId, ProtoEntry>>` and introduce `ProtoTypeId`, `ProtoEntry`, and `TypeInfo` structures to track per-type metadata and raw/generated content.
- Add a `TYPE_REGISTRY: HashMap<ProtoTypeId, TypeInfo>` and expose `register_type_info` so `#[proto_message(transparent)]` records the transparent proto type mapping which triggers rewriting of existing entries.
- Update macro plumbing to pass a `ProtoTypeId` when registering proto content, collect `module_path`/`type_name` into `UnifiedProtoConfig`, and compute transparent proto types via `transparent_proto_type` helper to populate `TypeInfo`.
- Implement content rewriting (`rewrite_proto_content`) to replace field proto types (including `map<...>` value types and `optional`/`repeated` modifiers) when transparent mappings are present, and add unit tests covering the rewrite behavior.

### Testing

- Ran the workspace test suite with `cargo test`, which completed successfully with all tests passing.
- Added a unit test `rewrites_transparent_types_in_proto_fields` for the proto content rewrite logic, and it passed under the test run.
- Existing macro and integration tests (including transparent-type roundtrips) were executed as part of the run and passed.
- The test run produced a minor unused-import warning in an example but did not affect test success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585a234e488321bb7600219635ab4b)