### PR TITLE
Reject `proto_path` for transparent `proto_message` types

### DIFF
--- a/crates/prosto_derive/src/proto_message/mod.rs
+++ b/crates/prosto_derive/src/proto_message/mod.rs
@@ -48,6 +48,12 @@ pub fn proto_message_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut config = UnifiedProtoConfig::from_attributes(attr, &type_ident, &input.attrs, &input.data);
     let proto_names = config.proto_message_names(&type_ident);
 
+    if config.transparent && config.proto_path().is_some() {
+        return Error::new_spanned(&input.ident, "transparent proto_message types must not be written to .proto files")
+            .to_compile_error()
+            .into();
+    }
+
     let tokens = match input.data {
         Data::Struct(ref data) => {
             for proto_name in &proto_names {


### PR DESCRIPTION
### Motivation

- Types marked `#[proto_message(transparent)]` must not be written to `.proto` files, and combining `transparent` with `proto_path` caused an invalid state.
- The change enforces a clear compile-time error to prevent accidental emission of transparent types into proto files.

### Description

- Added a guard in `proto_message_impl` to detect `config.transparent && config.proto_path().is_some()` and return a compile-time error.
- The error message returned is `"transparent proto_message types must not be written to .proto files"` to make the restriction explicit.
- Change applied in `crates/prosto_derive/src/proto_message/mod.rs` to prevent emitting `.proto` content for transparent types.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959615f911c8321915dfaa27157c628)