### PR TITLE
Expand proto_message generic bounds for repeated elements

### DIFF
--- a/crates/prosto_derive/src/proto_message/generic_bounds.rs
+++ b/crates/prosto_derive/src/proto_message/generic_bounds.rs
@@ -17,15 +17,17 @@ pub fn add_proto_wire_bounds<'a>(generics: &Generics, fields: impl IntoIterator<
     }
 
     let mut used = BTreeSet::new();
+    let mut used_ref = BTreeSet::new();
 
     for info in fields {
         if !uses_proto_wire_directly(info) {
             continue;
         }
-        collect_type_params(&info.field.ty, &type_params, &mut used);
+        collect_type_params(&info.parsed.rust_type, &type_params, &mut used);
+        collect_ref_type_params(&info.parsed.rust_type, &type_params, &mut used_ref);
     }
 
-    if used.is_empty() {
+    if used.is_empty() && used_ref.is_empty() {
         return generics.clone();
     }
 
@@ -36,6 +38,9 @@ pub fn add_proto_wire_bounds<'a>(generics: &Generics, fields: impl IntoIterator<
     }
     for ident in used {
         where_clause.predicates.push(parse_quote!(for<'a> #ident: ::proto_rs::EncodeInputFromRef<'a>));
+    }
+    for ident in used_ref {
+        where_clause.predicates.push(parse_quote!(for<'a> #ident: ::proto_rs::ProtoWire<EncodeInput<'a> = &'a #ident>));
     }
 
     bounded
@@ -138,5 +143,138 @@ fn collect_type_params(ty: &Type, params: &BTreeSet<Ident>, used: &mut BTreeSet<
             }
         }
         _ => {}
+    }
+}
+
+fn collect_ref_type_params(ty: &Type, params: &BTreeSet<Ident>, used: &mut BTreeSet<Ident>) {
+    collect_ref_type_params_inner(ty, params, used, false);
+}
+
+fn collect_ref_type_params_inner(ty: &Type, params: &BTreeSet<Ident>, used: &mut BTreeSet<Ident>, ref_position: bool) {
+    match ty {
+        Type::Array(array) => collect_ref_type_params_inner(&array.elem, params, used, true),
+        Type::Path(type_path) => {
+            if type_path.qself.is_none() && type_path.path.segments.len() == 1 {
+                let ident = &type_path.path.segments[0].ident;
+                if ref_position && params.contains(ident) {
+                    used.insert(ident.clone());
+                }
+            }
+
+            if type_path.qself.is_none() {
+                if let Some(segment) = type_path.path.segments.last() {
+                    match segment.ident.to_string().as_str() {
+                        "Vec" | "VecDeque" | "BTreeSet" | "HashSet" => {
+                            if let Some(inner_ty) = first_type_arg(&segment.arguments) {
+                                collect_ref_type_params_inner(inner_ty, params, used, true);
+                            }
+                        }
+                        "HashMap" | "BTreeMap" => {
+                            if let Some(key_ty) = first_type_arg(&segment.arguments) {
+                                collect_ref_type_params_inner(key_ty, params, used, true);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            for segment in &type_path.path.segments {
+                match &segment.arguments {
+                    PathArguments::None => {}
+                    PathArguments::AngleBracketed(args) => {
+                        for arg in &args.args {
+                            match arg {
+                                GenericArgument::Type(inner_ty) => collect_ref_type_params_inner(inner_ty, params, used, false),
+                                GenericArgument::AssocType(assoc) => collect_ref_type_params_inner(&assoc.ty, params, used, false),
+                                GenericArgument::Constraint(constraint) => {
+                                    for bound in &constraint.bounds {
+                                        if let syn::TypeParamBound::Trait(trait_bound) = bound {
+                                            for segment in &trait_bound.path.segments {
+                                                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                                                    for arg in &args.args {
+                                                        if let GenericArgument::Type(inner_ty) = arg {
+                                                            collect_ref_type_params_inner(inner_ty, params, used, false);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                GenericArgument::Lifetime(_) | GenericArgument::Const(_) | GenericArgument::AssocConst(_) | _ => {}
+                            }
+                        }
+                    }
+                    PathArguments::Parenthesized(args) => {
+                        for input in &args.inputs {
+                            collect_ref_type_params_inner(input, params, used, false);
+                        }
+                        if let syn::ReturnType::Type(_, output) = &args.output {
+                            collect_ref_type_params_inner(output, params, used, false);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(reference) => collect_ref_type_params_inner(&reference.elem, params, used, ref_position),
+        Type::Slice(slice) => collect_ref_type_params_inner(&slice.elem, params, used, ref_position),
+        Type::Tuple(tuple) => {
+            for elem in &tuple.elems {
+                collect_ref_type_params_inner(elem, params, used, ref_position);
+            }
+        }
+        Type::Paren(paren) => collect_ref_type_params_inner(&paren.elem, params, used, ref_position),
+        Type::Group(group) => collect_ref_type_params_inner(&group.elem, params, used, ref_position),
+        Type::Ptr(ptr) => collect_ref_type_params_inner(&ptr.elem, params, used, ref_position),
+        Type::BareFn(bare_fn) => {
+            for input in &bare_fn.inputs {
+                collect_ref_type_params_inner(&input.ty, params, used, ref_position);
+            }
+            if let syn::ReturnType::Type(_, output) = &bare_fn.output {
+                collect_ref_type_params_inner(output, params, used, ref_position);
+            }
+        }
+        Type::ImplTrait(impl_trait) => {
+            for bound in &impl_trait.bounds {
+                if let syn::TypeParamBound::Trait(trait_bound) = bound {
+                    for segment in &trait_bound.path.segments {
+                        if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                            for arg in &args.args {
+                                if let GenericArgument::Type(inner_ty) = arg {
+                                    collect_ref_type_params_inner(inner_ty, params, used, ref_position);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Type::TraitObject(trait_object) => {
+            for bound in &trait_object.bounds {
+                if let syn::TypeParamBound::Trait(trait_bound) = bound {
+                    for segment in &trait_bound.path.segments {
+                        if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                            for arg in &args.args {
+                                if let GenericArgument::Type(inner_ty) = arg {
+                                    collect_ref_type_params_inner(inner_ty, params, used, ref_position);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn first_type_arg(arguments: &PathArguments) -> Option<&Type> {
+    match arguments {
+        PathArguments::AngleBracketed(args) => args.args.iter().find_map(|arg| match arg {
+            GenericArgument::Type(inner_ty) => Some(inner_ty),
+            _ => None,
+        }),
+        _ => None,
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure `#[proto_message]` supports generic types nested in repeated/container positions (e.g. `Vec<K>`, `VecDeque<V>`, `BTreeSet<T>`) without emitting associated-type mismatch errors.
- Avoid over-constraining generic parameters used as message element types while adding stricter constraints only for repeated/borrowed encoding scenarios.

### Description
- Analyze `info.parsed.rust_type` instead of the raw field `ty` and collect two sets of type-params: general usage and reference/repeated usage via `collect_type_params` and `collect_ref_type_params`.
- Add `collect_ref_type_params_inner` traversal to detect nested container contexts (e.g. `Vec`, `VecDeque`, `HashSet`, `BTreeMap`, `BTreeSet`) and mark type parameters that must be encoded by reference.
- Emit additional `where` predicates `for<'a> #T: ::proto_rs::ProtoWire<EncodeInput<'a> = &'a #T>` for type params found in repeated/reference positions while retaining existing `EncodeInputFromRef` bounds.
- Implement helper `first_type_arg` and thread a `ref_position` flag to avoid over-applying ref-based constraints to non-repeated positions.

### Testing
- Ran `cargo test --all-features` from the workspace root.
- The full test suite completed successfully with no failures.
- The earlier failing scenario from `tests/generic_message.rs` (generic container roundtrip) now passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af50ae4e0832191d9753e645cc2b7)