### PR TITLE
Fix generic_types attribute parsing and regenerate generic proto messages

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -359,6 +359,8 @@ pub fn extract_item_validators(item_attrs: &[Attribute]) -> ItemValidators {
             }
 
             if meta.path.is_ident("generic_types") {
+                let value_parser = meta.value()?;
+                let _: Expr = value_parser.parse()?;
                 return Ok(());
             }
 
@@ -648,5 +650,19 @@ mod tests {
             suffixes,
             vec!["U64StringStdHashRandomState", "U64U16StdHashRandomState", "U32StringStdHashRandomState", "U32U16StdHashRandomState",]
         );
+    }
+
+    #[test]
+    fn parses_generic_types_attribute_values() {
+        let attrs: Vec<syn::Attribute> = vec![parse_quote! {
+            #[proto(generic_types = [T = [u64, u32], U = [String]])]
+        }];
+
+        let entries = extract_item_generic_types(&attrs);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].param.to_string(), "T");
+        assert_eq!(entries[0].types.len(), 2);
+        assert_eq!(entries[1].param.to_string(), "U");
+        assert_eq!(entries[1].types.len(), 1);
     }
 }

--- a/protos/gen_complex_proto/goon_types.proto
+++ b/protos/gen_complex_proto/goon_types.proto
@@ -18,6 +18,14 @@ message Id {
   uint64 id = 1;
 }
 
+message IdGenericU32 {
+  uint32 id = 1;
+}
+
+message IdGenericU64 {
+  uint64 id = 1;
+}
+
 message RizzPing {
   Id id = 1;
   ServiceStatus status = 2;


### PR DESCRIPTION
### Motivation
- Prevent proc-macro panics when encountering `#[proto(generic_types = ...)]` nested meta by properly consuming and validating its value.
- Ensure generic type combinations used by macros are accepted and exercised by unit tests.
- Regenerate proto artifacts to include concrete generic message variants used by the repository.

### Description
- Consume and validate the `generic_types` nested meta in `extract_item_validators` by parsing the meta value into an `Expr` (`crates/prosto_derive/src/parse.rs`).
- Add a unit test `parses_generic_types_attribute_values` that verifies extraction of `generic_types` entries (`crates/prosto_derive/src/parse.rs`).
- Regenerate `protos/gen_complex_proto/goon_types.proto` to include `IdGenericU32` and `IdGenericU64` message definitions.

### Testing
- Ran `cargo test --all-features`, which executed the full test suite and completed successfully with all tests passing.
- The new unit test `parses_generic_types_attribute_values` ran as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695beef8c4348321b4680315c60cca74)