### PR TITLE
Emit variant-specific PROTO_IDENT for generics; ignore NotFound in schemas::write_all

### DIFF
--- a/crates/prosto_derive/src/proto_message/mod.rs
+++ b/crates/prosto_derive/src/proto_message/mod.rs
@@ -122,7 +122,7 @@ pub fn proto_message_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         Data::Union(_) => Error::new_spanned(&input.ident, "proto_message cannot be used on unions").to_compile_error(),
     };
 
-    let proto_ident_const = assoc_proto_ident_const(&config, &input.ident, &input.generics, &proto_names);
+    let proto_ident_const = assoc_proto_ident_const(&config, &input.ident, &input.generics, &proto_names, &generic_variants);
     let proto_imports = config.imports_mat;
     quote! {
         #proto_imports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,11 @@ pub mod schemas {
     /// Will return `Err` if fs throws error
     pub fn write_all(output_dir: &str) -> io::Result<usize> {
         use std::fmt::Write;
-        fs::remove_dir_all(output_dir)?;
+        match fs::remove_dir_all(output_dir) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
         fs::create_dir_all(output_dir)?;
         let mut count = 0;
         let (registry, ident_index) = build_registry();


### PR DESCRIPTION
### Motivation
- Generic types declared with `#[proto(generic_types = ...)]` produced suffixed proto messages per variant, but the generated `PROTO_IDENT` used only the base proto name, causing schema imports to reference non-existent types.
- `schemas::write_all` unconditionally called `fs::remove_dir_all`, failing on first-run when the output directory did not yet exist.

### Description
- Update `assoc_proto_ident_const` to accept `generic_variants` and emit variant-specific `impl` blocks with `PROTO_IDENT` for each concrete substitution, using the suffixed proto name for `proto_type` and concrete type tokens like `Type<...>` for the impl target.
- Preserve the original behavior when `config.generic_types` is empty by emitting a single `PROTO_IDENT` impl using `generics.split_for_impl()`.
- Adjust `proto_message_impl` to pass `generic_variants` into `assoc_proto_ident_const` so per-variant id impls are generated for derived types.
- Make `schemas::write_all` ignore `io::ErrorKind::NotFound` from `fs::remove_dir_all` so creating a fresh output directory succeeds.

### Testing
- No automated tests were executed as part of this change.
- Changes were compiled and committed locally (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef9489ed88321b569f1d34953e896)