### PR TITLE
Fix schema inventory registration for build-schemas

### DIFF
--- a/crates/prosto_derive/src/schema.rs
+++ b/crates/prosto_derive/src/schema.rs
@@ -235,7 +235,7 @@ pub fn schema_tokens_for_imports(type_ident: &str, file_name: &str, imports: &[S
         const #const_name: &[&str] = &[#(#import_literals),*];
 
         #[cfg(feature = "build-schemas")]
-        const #schema_ident: ::proto_rs::schemas::ProtoSchema = ::proto_rs::schemas::ProtoSchema {
+        static #schema_ident: ::proto_rs::schemas::ProtoSchema = ::proto_rs::schemas::ProtoSchema {
             id: ::proto_rs::schemas::ProtoIdent {
                 module_path: ::core::module_path!(),
                 name: #type_ident,
@@ -304,7 +304,7 @@ fn build_schema_tokens(type_ident: &syn::Ident, proto_type: &str, config: &Unifi
 
     quote! {
         #[cfg(feature = "build-schemas")]
-        const #schema_ident: ::proto_rs::schemas::ProtoSchema = ::proto_rs::schemas::ProtoSchema {
+        static #schema_ident: ::proto_rs::schemas::ProtoSchema = ::proto_rs::schemas::ProtoSchema {
             id: ::proto_rs::schemas::ProtoIdent {
                 module_path: ::core::module_path!(),
                 name: stringify!(#type_ident),
@@ -393,7 +393,7 @@ fn build_generics_tokens(type_ident: &syn::Ident, suffix: &str, config: &Unified
                         const_type: ::core::option::Option::None,
                     };
                 });
-                generic_refs.push(quote! { &#generic_ident });
+                generic_refs.push(quote! { #generic_ident });
             }
             syn::GenericParam::Const(const_param) => {
                 let name = const_param.ident.to_string();
@@ -407,7 +407,7 @@ fn build_generics_tokens(type_ident: &syn::Ident, suffix: &str, config: &Unified
                         const_type: ::core::option::Option::Some(stringify!(#const_ty)),
                     };
                 });
-                generic_refs.push(quote! { &#generic_ident });
+                generic_refs.push(quote! { #generic_ident });
             }
             syn::GenericParam::Lifetime(_) => {}
         }
@@ -438,7 +438,7 @@ fn build_lifetime_tokens(type_ident: &syn::Ident, suffix: &str, config: &Unified
                     bounds: #bounds_ident,
                 };
             });
-            lifetime_refs.push(quote! { &#lifetime_ident });
+            lifetime_refs.push(quote! { #lifetime_ident });
         }
     }
 
@@ -463,7 +463,7 @@ fn build_attribute_tokens(type_ident: &syn::Ident, suffix: &str, attrs: &[syn::A
                 tokens: stringify!(#tokens),
             };
         });
-        attr_refs.push(quote! { &#attr_ident });
+        attr_refs.push(quote! { #attr_ident });
     }
 
     AttributeTokens {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub mod schemas {
     use std::sync::LazyLock;
 
     /// Represents a proto schema collected at compile time
+    #[derive(Clone, Copy)]
     pub struct ProtoSchema {
         pub id: ProtoIdent,
         pub generics: &'static [Generic],


### PR DESCRIPTION
### Motivation
- Fix compile errors caused by moving generated `ProtoSchema` values into `inventory` during schema codegen.
- Ensure generated schema registrations are stable and do not require moving non-`Copy` values.
- Emit schema-related metadata as value slices to simplify references and reduce surface for move errors.
- Improve maintainability of codegen for `build-schemas` feature.

### Description
- Switch generated schema items from `const` to `static` for `ProtoSchema` registrations in `crates/prosto_derive/src/schema.rs` so they can be submitted to `inventory` without ownership issues via `inventory::submit!`.
- Emit slices of values (e.g. generics, lifetimes, attributes) instead of slices of references by removing leading `&` when building the `*_refs` tokens in `crates/prosto_derive/src/schema.rs`.
- Mark `schemas::ProtoSchema` as `#[derive(Clone, Copy)]` in `src/lib.rs` to allow copying/submitting without move errors.
- Minor token/quote adjustments to make generated code consistent with the above changes.

### Testing
- Ran `cargo check --all-features` which completed successfully for the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695efc7ddd488321ba08bcd270c1fe36)