### PR TITLE
Fix proto schema generation for AtomicU8 vectors and transparent messages

### DIFF
--- a/protos/atomic_test.proto
+++ b/protos/atomic_test.proto
@@ -21,8 +21,8 @@ message AtomicWrapper {
   bool f13 = 16;
   uint32 f23 = 17;
   repeated bool f14 = 18;
-  repeated uint32 f24 = 19;
+  bytes f24 = 19;
   repeated bool f15 = 20;
-  repeated uint32 f25 = 21;
+  bytes f25 = 21;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure collections of atomic byte types (e.g. `Vec<AtomicU8>`) are emitted as `bytes` in generated .proto files instead of scalar numeric repeated fields.
- Make generated `ProtoSchema` output use the inner type for `#[proto_message(transparent)]` types when emitting fields and imports so schemas and imports are correct.
- Respect field-level transformations that affect schema emission (e.g. honoring `into`/`into_fn` and `skip` semantics when determining emitted proto identifiers).

### Description

- Added `is_byte_like` in `crates/prosto_derive/src/utils/type_info.rs` and updated `is_bytes_vec`/parsing logic to treat `AtomicU8` element types as byte-like so `Vec<AtomicU8>`/`VecDeque<AtomicU8>` map to `bytes`.
- Updated schema rendering in `src/lib.rs` to resolve transparent `proto_message` entries to their inner `ProtoIdent` via `resolve_transparent_ident`, and threaded `ident_index` into render/collect helpers so imports and field types use the inner type.
- Adjusted `render_entry`/`render_struct`/`render_field`/service rendering and import collection to use the resolved inner idents for transparent types.
- Updated generated `protos/atomic_test.proto` to reflect the correct `bytes` fields for atomic byte collections.

### Testing

- Ran `cargo test --all-features` from the workspace root.
- The test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f04f49fe08321adebff84b2563e2d)