### PR TITLE
Fix schema import output and extend proto_build_test coverage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,10 @@ pub mod schemas {
             let imports = collect_imports(entries.as_slice(), &ident_index, &file_name, &package_name)?;
             if !imports.is_empty() {
                 for import in &imports {
-                    writeln!(&mut output, "import \"{import}.proto\";").unwrap();
+                    let import_path = Path::new(import);
+                    let import_file = import_path.file_name().and_then(|name| name.to_str()).unwrap_or(import);
+                    let import_stem = import_file.strip_suffix(".proto").unwrap_or(import_file);
+                    writeln!(&mut output, "import \"{import_stem}.proto\";").unwrap();
                 }
                 output.push('\n');
             }

--- a/tests/proto_build_test/src/main.rs
+++ b/tests/proto_build_test/src/main.rs
@@ -45,14 +45,84 @@ pub struct FooResponse;
 #[derive(Clone, Debug, PartialEq)]
 pub struct BarSub;
 
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct MilliSeconds(pub i64);
+
+impl From<MilliSeconds> for i64 {
+    fn from(value: MilliSeconds) -> Self {
+        value.0
+    }
+}
+
+impl From<i64> for MilliSeconds {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+#[proto_message(transparent)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransparentId(pub Id);
+
+#[proto_message(proto_path = "protos/gen_complex_proto/extra_types.proto")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Envelope<T> {
+    #[proto(tag = 1)]
+    pub payload: T,
+    #[proto(tag = 2)]
+    pub trace_id: String,
+}
+
+#[proto_message(proto_path = "protos/gen_complex_proto/extra_types.proto")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BuildConfig {
+    #[proto(tag = 1, into = "i64")]
+    pub timeout: MilliSeconds,
+    #[proto(tag = 2, skip)]
+    pub cache_hint: String,
+    #[proto(tag = 3)]
+    pub owner: TransparentId,
+}
+
+#[proto_message(proto_path = "protos/gen_complex_proto/extra_types.proto")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BuildRequest {
+    #[proto(tag = 1)]
+    pub config: BuildConfig,
+    #[proto(tag = 2)]
+    pub ping: RizzPing,
+    #[proto(tag = 3)]
+    pub owner: TransparentId,
+}
+
+#[proto_message(proto_path = "protos/gen_complex_proto/extra_types.proto")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BuildResponse {
+    #[proto(tag = 1)]
+    pub status: ServiceStatus,
+    #[proto(tag = 2)]
+    pub envelope: Envelope<GoonPong>,
+}
+
 // Define trait with the proto_rpc macro
 #[proto_rpc(rpc_package = "sigma_rpc", rpc_server = true, rpc_client = true, proto_path = "protos/gen_complex_proto/sigma_rpc_simple.proto")]
-#[proto_imports(rizz_types = ["BarSub", "FooResponse"], goon_types = ["RizzPing", "GoonPong", "ServiceStatus", "Id"] )]
+#[proto_imports(
+    rizz_types = ["BarSub", "FooResponse"],
+    goon_types = ["RizzPing", "GoonPong", "ServiceStatus", "Id"],
+    extra_types = ["Envelope", "BuildConfig", "BuildRequest", "BuildResponse"]
+)]
 pub trait SigmaRpc {
     type RizzUniStream: Stream<Item = Result<ZeroCopyResponse<FooResponse>, Status>> + Send;
     async fn rizz_ping(&self, request: Request<RizzPing>) -> Result<Response<GoonPong>, Status>;
 
     async fn rizz_uni(&self, request: Request<BarSub>) -> Result<Response<Self::RizzUniStream>, Status>;
+
+    async fn build(
+        &self,
+        request: Request<Envelope<BuildRequest>>,
+    ) -> Result<Response<Envelope<BuildResponse>>, Status>;
+
+    async fn owner_lookup(&self, request: Request<TransparentId>) -> Result<Response<BuildResponse>, Status>;
 }
 
 use proto_rs::schemas::ProtoSchema;


### PR DESCRIPTION
### Motivation

- Fix incorrect generated import lines which produced duplicated or path-prefixed names like `protos/.../foo.proto.proto` instead of simple `foo.proto` when writing schemas via `schemas::write_all`.
- Ensure the build-time proto generation supports generics, transparent types, and fields using `skip` and `into` attributes by exercising them in the proto build test.

### Description

- Normalize emitted import statements in `schemas::write_all` by taking the file basename and stripping a trailing `.proto` before writing `import "{name}.proto";`.
- Extend `tests/proto_build_test` with new types: `MilliSeconds`, transparent `TransparentId`, generic `Envelope<T>`, `BuildConfig` (uses `into` and `skip`), `BuildRequest`, and `BuildResponse`, and register them in `proto_imports` and RPC method signatures to exercise generation paths.
- All changes are limited to `src/lib.rs` (import normalization) and `tests/proto_build_test/src/main.rs` (test additions).

### Testing

- Ran `cargo test --all-features --no-run` to build with all features enabled and verify codegen and proc-macros compile.
- The compilation finished successfully and test binaries were produced, noting tests were not executed (only compilation was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0d4379bc8321aa7e1a1ed39716b4)