### PR TITLE
Fix proto schema generation for transparent and generic types

### DIFF
--- a/crates/prosto_derive/src/parse.rs
+++ b/crates/prosto_derive/src/parse.rs
@@ -101,6 +101,9 @@ impl UnifiedProtoConfig {
             let mat = register_and_emit_proto_inner(proto_path, content, schema_tokens);
             let imports = &self.imports_mat;
             self.imports_mat = quote::quote! { #imports #mat };
+        } else if self.transparent {
+            let imports = &self.imports_mat;
+            self.imports_mat = quote::quote! { #imports #schema_tokens };
         }
     }
 

--- a/protos/gen_complex_proto/goon_types.proto
+++ b/protos/gen_complex_proto/goon_types.proto
@@ -18,6 +18,14 @@ message Id {
   uint64 id = 1;
 }
 
+message IdGenericU32 {
+  uint32 id = 1;
+}
+
+message IdGenericU64 {
+  uint64 id = 1;
+}
+
 message RizzPing {
   Id id = 1;
   ServiceStatus status = 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,10 +311,10 @@ pub mod schemas {
         let mut ident_index = BTreeMap::new();
 
         for schema in inventory::iter::<ProtoSchema>() {
-            if schema.id.proto_file_path.is_empty() {
+            if ident_index.insert(schema.id, schema).is_some() {
                 continue;
             }
-            if ident_index.insert(schema.id, schema).is_some() {
+            if schema.id.proto_file_path.is_empty() {
                 continue;
             }
             registry.entry(schema.id.proto_file_path.to_string()).or_insert_with(Vec::new).push(schema);

--- a/tests/proto_build_test/build_protos/protos/gen_complex_proto/extra_types.proto
+++ b/tests/proto_build_test/build_protos/protos/gen_complex_proto/extra_types.proto
@@ -6,22 +6,32 @@ import "goon_types.proto";
 
 message BuildConfig {
   int64 timeout = 1;
-  TransparentId owner = 3;
+  goon_types.Id owner = 3;
 }
 
 message BuildRequest {
   BuildConfig config = 1;
   goon_types.RizzPing ping = 2;
-  TransparentId owner = 3;
+  goon_types.Id owner = 3;
 }
 
 message BuildResponse {
   goon_types.ServiceStatus status = 1;
-  Envelope envelope = 2;
+  EnvelopeGoonPong envelope = 2;
 }
 
-message Envelope {
-  bytes payload = 1;
+message EnvelopeBuildRequest {
+  BuildRequest payload = 1;
+  string trace_id = 2;
+}
+
+message EnvelopeBuildResponse {
+  BuildResponse payload = 1;
+  string trace_id = 2;
+}
+
+message EnvelopeGoonPong {
+  goon_types.GoonPong payload = 1;
   string trace_id = 2;
 }
 

--- a/tests/proto_build_test/build_protos/protos/gen_complex_proto/sigma_rpc_simple.proto
+++ b/tests/proto_build_test/build_protos/protos/gen_complex_proto/sigma_rpc_simple.proto
@@ -9,6 +9,6 @@ import "rizz_types.proto";
 service SigmaRpc {
   rpc RizzPing(goon_types.RizzPing) returns (goon_types.GoonPong);
   rpc RizzUni(rizz_types.BarSub) returns (stream rizz_types.FooResponse);
-  rpc Build(extra_types.Envelope) returns (extra_types.Envelope);
-  rpc OwnerLookup(TransparentId) returns (extra_types.BuildResponse);
+  rpc Build(extra_types.EnvelopeBuildRequest) returns (extra_types.EnvelopeBuildResponse);
+  rpc OwnerLookup(goon_types.Id) returns (extra_types.BuildResponse);
 }

--- a/tests/proto_build_test/src/main.rs
+++ b/tests/proto_build_test/src/main.rs
@@ -65,6 +65,7 @@ impl From<i64> for MilliSeconds {
 pub struct TransparentId(pub Id);
 
 #[proto_message(proto_path = "protos/gen_complex_proto/extra_types.proto")]
+#[proto(generic_types = [T = [BuildRequest, BuildResponse, GoonPong]])]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Envelope<T> {
     #[proto(tag = 1)]
@@ -109,7 +110,7 @@ pub struct BuildResponse {
 #[proto_imports(
     rizz_types = ["BarSub", "FooResponse"],
     goon_types = ["RizzPing", "GoonPong", "ServiceStatus", "Id"],
-    extra_types = ["Envelope", "BuildConfig", "BuildRequest", "BuildResponse"]
+    extra_types = ["EnvelopeBuildRequest", "EnvelopeBuildResponse", "BuildConfig", "BuildRequest", "BuildResponse"]
 )]
 pub trait SigmaRpc {
     type RizzUniStream: Stream<Item = Result<ZeroCopyResponse<FooResponse>, Status>> + Send;


### PR DESCRIPTION
### Motivation
- Transparent wrapper types were not being resolved when emitting proto definitions, producing references to the wrapper rather than the inner type. 
- Generic types were emitted as their original generic names instead of concrete concrete-specialized messages (e.g. `Envelope<T>` vs `EnvelopeGoonPong`).
- The schema registry and emitted schema metadata needed to expose transparent and concrete-generic information so `write_all` can correctly collect, resolve, and render imported types.

### Description
- Ensure every `ProtoSchema` is indexed first in `build_registry` so transparent schemas (even without a `proto_file_path`) are available for resolution by moving the `ident_index.insert` check before the proto path filter in `build_registry` (`src/lib.rs`).
- Add a synthetic `transparent` attribute into emitted schema metadata by extending `build_attribute_tokens` with an `include_transparent` flag and injecting a top-level attribute when a type is `transparent` (`crates/prosto_derive/src/schema.rs`).
- Emit schema tokens for transparent types even when no `proto_path` is specified by appending the schema tokens into `imports_mat` for transparent items in `register_and_emit_proto` so `write_all` can find and resolve inner types (`crates/prosto_derive/src/parse.rs`).
- Update test inputs to define concrete generic variants via `#[proto(generic_types = ...)]` for `Envelope<T>` and adjust `proto_imports` to reference the generated concrete message names, and regenerate expected proto files in the test outputs (files under `tests/proto_build_test/build_protos/protos/gen_complex_proto` and `protos/gen_complex_proto`).

### Testing
- Ran `cargo run` in `tests/proto_build_test` and the binary executed successfully, generating the updated proto files and printing collected schemas (inspection shows resolved transparent IDs and concrete generic messages).
- Ran `cargo test --all-features --no-run` (compile-only); the run was attempted but interrupted before completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1a6c44508321adca41c3318bb668)