### PR TITLE
Fix schema sun proto identifiers for RPC services

### DIFF
--- a/crates/prosto_derive/src/schema.rs
+++ b/crates/prosto_derive/src/schema.rs
@@ -147,19 +147,19 @@ fn build_sun_trait_impls(
     config: &UnifiedProtoConfig,
     impl_generics: &TokenStream2,
     where_clause: &TokenStream2,
-    proto_name_literal: &String,
+    _proto_name_literal: &String,
     proto_ident_literal: &impl Fn(&String) -> TokenStream2,
 ) -> TokenStream2 {
     if !config.has_suns() {
         return quote! {};
     }
 
-    let proto_ident = proto_ident_literal(proto_name_literal);
     let sun_impls: Vec<_> = config
         .suns
         .iter()
         .map(|sun| {
             let sun_ty = &sun.ty;
+            let proto_ident = proto_ident_literal(&sun.message_ident);
             quote! {
                 #[cfg(feature = "build-schemas")]
                 impl #impl_generics ::proto_rs::schemas::ProtoIdentifiable for #sun_ty #where_clause {


### PR DESCRIPTION
### Motivation
- The proto schema generator incorrectly used the primary message name when emitting `ProtoIdentifiable` for `sun` variants, causing RPC methods to reference the wrong proto type (e.g. `D128` instead of `D64`).
- The schema generation path needed to bind each `sun` type to its own proto identifier so generated `.proto` files and service signatures are correct.
- A small unused-parameter warning was produced from the previous implementation and should be silenced.

### Description
- Change `build_sun_trait_impls` to generate `ProtoIdentifiable` for each `sun` using `proto_ident_literal(&sun.message_ident)` so each sun maps to its own proto ident in `crates/prosto_derive/src/schema.rs`.
- Rename the unused parameter to `_proto_name_literal` to avoid the unused-variable warning.
- The change ensures RPC service method schema entries use the correct `sun` proto type when rendering `.proto` files.

### Testing
- Ran `cargo test --all-features --no-run` which compiled the test profile and produced the unit test binaries successfully. (Succeeded)
- Ran `cargo run -p proto_build_test` to generate `.proto` files and verify output, and confirmed the generated service now contains `returns (fastnum.D64)` for the `TestDecimals` RPC method. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2363afa08321aca7c5e6b4d3325c)