### PR TITLE
Fix rust client generation and schema output

### DIFF
--- a/src/schemas/proto_output.rs
+++ b/src/schemas/proto_output.rs
@@ -1,0 +1,396 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use super::Field;
+use super::ProtoEntry;
+use super::ProtoIdent;
+use super::ProtoLabel;
+use super::ProtoSchema;
+use super::ServiceMethod;
+use super::Variant;
+use super::utils::entry_sort_key;
+use super::utils::resolve_transparent_ident;
+use super::utils::to_snake_case;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct GenericSpecialization {
+    pub(crate) name: String,
+    pub(crate) args: Vec<ProtoIdent>,
+}
+
+pub(crate) fn collect_imports(entries: &[&ProtoSchema], ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, file_name: &str, package_name: &str) -> std::io::Result<BTreeSet<String>> {
+    let mut imports = BTreeSet::new();
+
+    for entry in entries {
+        match entry.content {
+            ProtoEntry::Import { paths } => {
+                for path in paths {
+                    imports.insert(path.to_string());
+                }
+            }
+            ProtoEntry::Struct { fields } => {
+                collect_field_imports(&mut imports, ident_index, fields, file_name, package_name)?;
+            }
+            ProtoEntry::SimpleEnum { .. } => {}
+            ProtoEntry::ComplexEnum { variants } => {
+                for variant in variants {
+                    collect_field_imports(&mut imports, ident_index, variant.fields, file_name, package_name)?;
+                }
+            }
+            ProtoEntry::Service { methods, .. } => {
+                collect_service_imports(&mut imports, ident_index, methods, file_name, package_name)?;
+            }
+        }
+    }
+
+    Ok(imports)
+}
+
+pub(crate) fn collect_generic_specializations(entries: &[&ProtoSchema], ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>) -> BTreeMap<ProtoIdent, Vec<GenericSpecialization>> {
+    let mut specializations: BTreeMap<ProtoIdent, Vec<GenericSpecialization>> = BTreeMap::new();
+    let generic_entries: BTreeMap<ProtoIdent, &ProtoSchema> = entries
+        .iter()
+        .filter(|entry| entry.generics.iter().any(|generic| matches!(generic.kind, super::GenericKind::Type)))
+        .map(|entry| (entry.id, *entry))
+        .collect();
+
+    let mut register_specialization = |base: ProtoIdent, args: &[&ProtoIdent]| {
+        if !generic_entries.contains_key(&base) {
+            return;
+        }
+        let concrete_args: Vec<ProtoIdent> = args.iter().map(|arg| **arg).collect();
+        let name = specialized_proto_name(base, &concrete_args);
+        let entry = specializations.entry(base).or_default();
+        if entry.iter().all(|existing| existing.name != name) {
+            entry.push(GenericSpecialization { name, args: concrete_args });
+        }
+    };
+
+    for entry in entries {
+        match entry.content {
+            ProtoEntry::Struct { fields } => {
+                for field in fields {
+                    if !field.generic_args.is_empty() {
+                        register_specialization(field.proto_ident, field.generic_args);
+                    }
+                }
+            }
+            ProtoEntry::ComplexEnum { variants } => {
+                for variant in variants {
+                    for field in variant.fields {
+                        if !field.generic_args.is_empty() {
+                            register_specialization(field.proto_ident, field.generic_args);
+                        }
+                    }
+                }
+            }
+            ProtoEntry::Service { methods, .. } => {
+                for method in methods {
+                    if !method.request_generic_args.is_empty() {
+                        register_specialization(method.request, method.request_generic_args);
+                    }
+                    if !method.response_generic_args.is_empty() {
+                        register_specialization(method.response, method.response_generic_args);
+                    }
+                }
+            }
+            ProtoEntry::SimpleEnum { .. } | ProtoEntry::Import { .. } => {}
+        }
+    }
+
+    for entry in specializations.values_mut() {
+        entry.sort_by(|left, right| left.name.cmp(&right.name));
+    }
+
+    let mut ordered = specializations;
+    for (base, specs) in &mut ordered {
+        let base_entry = ident_index.get(base);
+        if let Some(base_entry) = base_entry {
+            let param_count = base_entry.generics.iter().filter(|generic| matches!(generic.kind, super::GenericKind::Type)).count();
+            specs.retain(|spec| spec.args.len() == param_count);
+        }
+    }
+
+    ordered
+}
+
+pub(crate) fn render_entries(
+    entries: &[&ProtoSchema],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    specializations: &BTreeMap<ProtoIdent, Vec<GenericSpecialization>>,
+) -> Vec<String> {
+    let mut ordered_entries = entries.to_vec();
+    ordered_entries.sort_by(|left, right| entry_sort_key(left).cmp(&entry_sort_key(right)));
+
+    let mut rendered = Vec::new();
+    for entry in ordered_entries {
+        let specs = specializations.get(&entry.id);
+        rendered.extend(render_entry(entry, package_name, ident_index, specs));
+    }
+    rendered
+}
+
+fn render_entry(entry: &ProtoSchema, package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, specializations: Option<&Vec<GenericSpecialization>>) -> Vec<String> {
+    let type_generics: Vec<&str> = entry
+        .generics
+        .iter()
+        .filter(|generic| matches!(generic.kind, super::GenericKind::Type))
+        .map(|generic| generic.name)
+        .collect();
+
+    let has_type_generics = !type_generics.is_empty();
+    if has_type_generics {
+        let Some(specs) = specializations else {
+            return Vec::new();
+        };
+        let mut rendered = Vec::new();
+        for spec in specs {
+            let substitution = build_substitution(&type_generics, &spec.args);
+            let definition = match entry.content {
+                ProtoEntry::Struct { fields } => render_struct(&spec.name, fields, package_name, ident_index, Some(&substitution)),
+                ProtoEntry::SimpleEnum { variants } => render_simple_enum(&spec.name, variants),
+                ProtoEntry::ComplexEnum { variants } => render_complex_enum(&spec.name, variants, package_name, ident_index, Some(&substitution)),
+                ProtoEntry::Import { .. } => continue,
+                ProtoEntry::Service { methods, .. } => render_service(&spec.name, methods, package_name, ident_index, Some(&substitution)),
+            };
+            rendered.push(definition);
+        }
+        return rendered;
+    }
+
+    let definition = match entry.content {
+        ProtoEntry::Struct { fields } => render_struct(entry.id.proto_type, fields, package_name, ident_index, None),
+        ProtoEntry::SimpleEnum { variants } => render_simple_enum(entry.id.proto_type, variants),
+        ProtoEntry::ComplexEnum { variants } => render_complex_enum(entry.id.proto_type, variants, package_name, ident_index, None),
+        ProtoEntry::Import { .. } => return Vec::new(),
+        ProtoEntry::Service { methods, .. } => render_service(entry.id.proto_type, methods, package_name, ident_index, None),
+    };
+
+    vec![definition]
+}
+
+fn build_substitution<'a>(type_generics: &'a [&'a str], args: &'a [ProtoIdent]) -> BTreeMap<&'a str, ProtoIdent> {
+    let mut substitution = BTreeMap::new();
+    for (idx, name) in type_generics.iter().enumerate() {
+        if let Some(arg) = args.get(idx) {
+            substitution.insert(*name, *arg);
+        }
+    }
+    substitution
+}
+
+fn render_struct(name: &str, fields: &[&Field], package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    if fields.is_empty() {
+        return format!("message {name} {{}}\n");
+    }
+
+    let mut lines = Vec::new();
+    for (idx, field) in fields.iter().enumerate() {
+        lines.push(render_field(field, idx, package_name, ident_index, substitution));
+    }
+
+    format!("message {name} {{\n{}\n}}\n", lines.join("\n"))
+}
+
+fn render_simple_enum(name: &str, variants: &[&Variant]) -> String {
+    let mut lines = Vec::new();
+    for variant in variants {
+        let value = variant.discriminant.unwrap_or_default();
+        lines.push(format!("  {} = {};", variant.name, value));
+    }
+    format!("enum {name} {{\n{}\n}}\n", lines.join("\n"))
+}
+
+fn render_complex_enum(name: &str, variants: &[&Variant], package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    let mut nested_messages = Vec::new();
+    let mut oneof_fields = Vec::new();
+
+    for (idx, variant) in variants.iter().enumerate() {
+        let tag = idx + 1;
+        let variant_name = variant.name;
+        let field_name = to_snake_case(variant_name);
+
+        if variant.fields.is_empty() {
+            let msg_name = format!("{name}{variant_name}");
+            nested_messages.push(format!("message {msg_name} {{}}"));
+            oneof_fields.push(format!("    {msg_name} {field_name} = {tag};"));
+            continue;
+        }
+
+        if variant.fields.len() == 1 && variant.fields[0].name.is_none() {
+            let proto_type = field_type_name(variant.fields[0], package_name, ident_index, substitution);
+            oneof_fields.push(format!("    {proto_type} {field_name} = {tag};"));
+            continue;
+        }
+
+        let msg_name = format!("{name}{variant_name}");
+        let field_defs = render_named_fields(variant.fields, package_name, ident_index, substitution);
+        nested_messages.push(format!("message {msg_name} {{\n{field_defs}\n}}"));
+        oneof_fields.push(format!("    {msg_name} {field_name} = {tag};"));
+    }
+
+    format!("{}\nmessage {} {{\n  oneof value {{\n{}\n  }}\n}}\n", nested_messages.join("\n\n"), name, oneof_fields.join("\n"))
+}
+
+fn render_named_fields(fields: &[&Field], package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    let mut lines = Vec::new();
+    for (idx, field) in fields.iter().enumerate() {
+        lines.push(render_field(field, idx, package_name, ident_index, substitution));
+    }
+    lines.join("\n")
+}
+
+fn render_field(field: &Field, idx: usize, package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    let name = field.name.map_or_else(|| format!("field_{idx}"), ToString::to_string);
+    let label = match field.proto_label {
+        ProtoLabel::None => "",
+        ProtoLabel::Optional => "optional ",
+        ProtoLabel::Repeated => "repeated ",
+    };
+    let proto_type = field_type_name(field, package_name, ident_index, substitution);
+    format!("  {label}{proto_type} {name} = {};", field.tag)
+}
+
+fn render_service(name: &str, methods: &[&ServiceMethod], package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("service {name} {{"));
+
+    for method in methods {
+        let request_type = proto_ident_type_name_with_generics(method.request, method.request_generic_args, package_name, ident_index, substitution);
+        let response_type = proto_ident_type_name_with_generics(method.response, method.response_generic_args, package_name, ident_index, substitution);
+        let response_type = if method.server_streaming { format!("stream {response_type}") } else { response_type };
+        lines.push(format!("  rpc {}({}) returns ({});", method.name, request_type, response_type));
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
+}
+
+fn field_type_name(field: &Field, package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> String {
+    let ident = resolve_transparent_ident(field.proto_ident, ident_index);
+    if ident.proto_type.starts_with("map<") {
+        return ident.proto_type.to_string();
+    }
+
+    proto_ident_type_name_with_generics(ident, field.generic_args, package_name, ident_index, substitution)
+}
+
+fn proto_ident_type_name_with_generics(
+    ident: ProtoIdent,
+    generic_args: &[&ProtoIdent],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    substitution: Option<&BTreeMap<&str, ProtoIdent>>,
+) -> String {
+    let ident = apply_substitution(ident, substitution);
+    if generic_args.is_empty() {
+        return proto_ident_type_name(ident, package_name, ident_index);
+    }
+
+    let mut resolved_args = Vec::new();
+    for arg in generic_args {
+        let resolved = apply_substitution(**arg, substitution);
+        resolved_args.push(resolved);
+    }
+
+    let specialized_name = specialized_proto_name(ident, &resolved_args);
+    let ident = resolve_transparent_ident(ident, ident_index);
+    if ident.proto_package_name.is_empty() || ident.proto_package_name == package_name {
+        specialized_name
+    } else {
+        format!("{}.{}", ident.proto_package_name, specialized_name)
+    }
+}
+
+fn specialized_proto_name(base: ProtoIdent, args: &[ProtoIdent]) -> String {
+    let mut name = base.proto_type.to_string();
+    for arg in args {
+        name.push_str(arg.proto_type);
+    }
+    name
+}
+
+fn proto_ident_type_name(ident: ProtoIdent, package_name: &str, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>) -> String {
+    let ident = resolve_transparent_ident(ident, ident_index);
+    if ident.proto_package_name.is_empty() || ident.proto_package_name == package_name {
+        ident.proto_type.to_string()
+    } else {
+        format!("{}.{}", ident.proto_package_name, ident.proto_type)
+    }
+}
+
+fn apply_substitution(ident: ProtoIdent, substitution: Option<&BTreeMap<&str, ProtoIdent>>) -> ProtoIdent {
+    let Some(substitution) = substitution else {
+        return ident;
+    };
+    substitution.get(ident.proto_type).copied().unwrap_or(ident)
+}
+
+fn collect_field_imports(imports: &mut BTreeSet<String>, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>, fields: &[&Field], file_name: &str, package_name: &str) -> std::io::Result<()> {
+    for field in fields {
+        let ident = resolve_transparent_ident(field.proto_ident, ident_index);
+        collect_proto_ident_imports(imports, ident_index, &ident, file_name, package_name)?;
+        for arg in field.generic_args {
+            let arg_ident = resolve_transparent_ident(**arg, ident_index);
+            collect_proto_ident_imports(imports, ident_index, &arg_ident, file_name, package_name)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_service_imports(
+    imports: &mut BTreeSet<String>,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    methods: &[&ServiceMethod],
+    file_name: &str,
+    package_name: &str,
+) -> std::io::Result<()> {
+    for method in methods {
+        let request = resolve_transparent_ident(method.request, ident_index);
+        let response = resolve_transparent_ident(method.response, ident_index);
+        collect_proto_ident_imports(imports, ident_index, &request, file_name, package_name)?;
+        collect_proto_ident_imports(imports, ident_index, &response, file_name, package_name)?;
+        for arg in method.request_generic_args {
+            let arg_ident = resolve_transparent_ident(**arg, ident_index);
+            collect_proto_ident_imports(imports, ident_index, &arg_ident, file_name, package_name)?;
+        }
+        for arg in method.response_generic_args {
+            let arg_ident = resolve_transparent_ident(**arg, ident_index);
+            collect_proto_ident_imports(imports, ident_index, &arg_ident, file_name, package_name)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_proto_ident_imports(
+    imports: &mut BTreeSet<String>,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    ident: &ProtoIdent,
+    file_name: &str,
+    package_name: &str,
+) -> std::io::Result<()> {
+    if ident.proto_file_path.is_empty() {
+        return Ok(());
+    }
+
+    if ident.proto_file_path == file_name {
+        return Ok(());
+    }
+
+    if ident.proto_package_name.is_empty() && ident.proto_file_path.is_empty() {
+        return Ok(());
+    }
+
+    if ident.proto_package_name != package_name || ident.proto_file_path != file_name {
+        if !ident.module_path.is_empty() && !ident_index.contains_key(ident) {
+            return Err(std::io::Error::other(format!(
+                "unresolved ProtoIdent for {} (file: {}, package: {})",
+                ident.proto_type, ident.proto_file_path, ident.proto_package_name
+            )));
+        }
+        imports.insert(ident.proto_file_path.to_string());
+    }
+
+    Ok(())
+}

--- a/src/schemas/rust_client.rs
+++ b/src/schemas/rust_client.rs
@@ -1,0 +1,869 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt::Write;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use super::Field;
+use super::GenericKind;
+use super::ProtoEntry;
+use super::ProtoIdent;
+use super::ProtoLabel;
+use super::ProtoSchema;
+use super::ServiceMethod;
+use super::Variant;
+use super::utils::indent_line;
+use super::utils::module_path_for_package;
+use super::utils::module_path_segments;
+use super::utils::parse_map_types;
+use super::utils::proto_scalar_type;
+use super::utils::resolve_transparent_ident;
+use super::utils::rust_type_name;
+use super::utils::to_snake_case;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ClientImport {
+    pub(crate) path: String,
+    pub(crate) type_name: String,
+    pub(crate) alias: Option<String>,
+}
+
+impl ClientImport {
+    pub(crate) fn render_use(&self) -> String {
+        match &self.alias {
+            Some(alias) => format!("{} as {}", self.path, alias),
+            None => self.path.clone(),
+        }
+    }
+
+    pub(crate) fn render_type(&self) -> String {
+        self.alias.as_deref().unwrap_or(&self.type_name).to_string()
+    }
+}
+
+pub(crate) fn write_rust_client_module(
+    output_path: &str,
+    imports: &[&str],
+    registry: &BTreeMap<String, Vec<&'static ProtoSchema>>,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+) -> io::Result<()> {
+    let client_imports = parse_client_imports(imports);
+    let client_imports_by_type = client_imports.iter().map(|import| (import.type_name.clone(), import.clone())).collect::<BTreeMap<_, _>>();
+    let mut package_by_ident = BTreeMap::new();
+    let mut root = ModuleNode::default();
+    let proto_type_index = build_proto_type_index(registry);
+
+    for (file_name, entries) in registry {
+        let package_name = package_name_for_entries(file_name, entries);
+        let module_segments = module_path_segments(&package_name);
+        for entry in entries {
+            package_by_ident.insert(entry.id, package_name.clone());
+            if client_imports_by_type.contains_key(&rust_type_name(entry.id)) {
+                continue;
+            }
+            if matches!(entry.content, ProtoEntry::Import { .. }) {
+                continue;
+            }
+            insert_module_entry(&mut root, &module_segments, &package_name, entry);
+        }
+    }
+
+    let mut output = String::new();
+    output.push_str("//CODEGEN BELOW - DO NOT TOUCH ME\n");
+
+    if !root.entries.is_empty() {
+        output.push_str("#[allow(unused_imports)]\n");
+        output.push_str("use proto_rs::{proto_message, proto_rpc};\n");
+        render_module_imports(
+            &mut output,
+            &root.entries,
+            root.package_name.as_deref().unwrap_or(""),
+            ident_index,
+            &package_by_ident,
+            &proto_type_index,
+            &client_imports_by_type,
+            0,
+        );
+        output.push('\n');
+        render_entries(
+            &mut output,
+            &root.entries,
+            root.package_name.as_deref().unwrap_or(""),
+            ident_index,
+            &package_by_ident,
+            &proto_type_index,
+            &client_imports_by_type,
+            0,
+        );
+        output.push('\n');
+    }
+
+    for (name, child) in &root.children {
+        render_named_module(&mut output, name, child, 0, ident_index, &package_by_ident, &proto_type_index, &client_imports_by_type);
+    }
+
+    if let Some(parent) = Path::new(output_path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(output_path, output)?;
+    Ok(())
+}
+
+fn parse_client_imports(imports: &[&str]) -> Vec<ClientImport> {
+    imports.iter().filter_map(|import| parse_client_import(*import)).collect()
+}
+
+fn parse_client_import(import: &str) -> Option<ClientImport> {
+    let mut trimmed = import.trim().trim_end_matches(';').trim();
+    if let Some(stripped) = trimmed.strip_prefix("use ") {
+        trimmed = stripped.trim();
+    }
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (path, alias) = if let Some((left, right)) = trimmed.split_once(" as ") {
+        (left.trim(), Some(right.trim()))
+    } else {
+        (trimmed, None)
+    };
+    let type_name = alias.map(str::to_string).or_else(|| path.split("::").last().map(ToString::to_string))?;
+    Some(ClientImport {
+        path: path.to_string(),
+        type_name,
+        alias: alias.map(ToString::to_string),
+    })
+}
+
+#[derive(Default)]
+struct ModuleNode {
+    package_name: Option<String>,
+    entries: Vec<&'static ProtoSchema>,
+    children: BTreeMap<String, ModuleNode>,
+}
+
+fn insert_module_entry(node: &mut ModuleNode, segments: &[String], package_name: &str, entry: &'static ProtoSchema) {
+    if segments.is_empty() {
+        node.package_name = Some(package_name.to_string());
+        node.entries.push(entry);
+        return;
+    }
+    let child = node.children.entry(segments[0].clone()).or_default();
+    insert_module_entry(child, &segments[1..], package_name, entry);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_named_module(
+    output: &mut String,
+    name: &str,
+    node: &ModuleNode,
+    indent: usize,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) {
+    indent_line(output, indent);
+    output.push_str("pub mod ");
+    output.push_str(name);
+    output.push_str(" {\n");
+
+    let inner_indent = indent + 4;
+    if !node.entries.is_empty() {
+        indent_line(output, inner_indent);
+        output.push_str("#[allow(unused_imports)]\n");
+        indent_line(output, inner_indent);
+        output.push_str("use proto_rs::{proto_message, proto_rpc};\n");
+        render_module_imports(
+            output,
+            &node.entries,
+            node.package_name.as_deref().unwrap_or(""),
+            ident_index,
+            package_by_ident,
+            proto_type_index,
+            client_imports,
+            inner_indent,
+        );
+        output.push('\n');
+    }
+
+    render_entries(
+        output,
+        &node.entries,
+        node.package_name.as_deref().unwrap_or(""),
+        ident_index,
+        package_by_ident,
+        proto_type_index,
+        client_imports,
+        inner_indent,
+    );
+
+    for (child_name, child) in &node.children {
+        render_named_module(output, child_name, child, inner_indent, ident_index, package_by_ident, proto_type_index, client_imports);
+    }
+
+    indent_line(output, indent);
+    output.push_str("}\n");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_module_imports(
+    output: &mut String,
+    entries: &[&'static ProtoSchema],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) {
+    let imports = collect_module_imports(entries, package_name, ident_index, package_by_ident, proto_type_index, client_imports);
+    for import in imports {
+        indent_line(output, indent);
+        output.push_str("use ");
+        output.push_str(&import);
+        output.push_str(";\n");
+    }
+}
+
+fn collect_module_imports(
+    entries: &[&'static ProtoSchema],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> BTreeSet<String> {
+    let mut imports = BTreeSet::new();
+    for entry in entries {
+        match entry.content {
+            ProtoEntry::Struct { fields } => {
+                for field in fields {
+                    collect_rust_field_imports(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports, &mut imports);
+                }
+            }
+            ProtoEntry::ComplexEnum { variants } => {
+                for variant in variants {
+                    for field in variant.fields {
+                        collect_rust_field_imports(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports, &mut imports);
+                    }
+                }
+            }
+            ProtoEntry::Service { methods, .. } => {
+                for method in methods {
+                    let request = resolve_transparent_ident(method.request, ident_index);
+                    let response = resolve_transparent_ident(method.response, ident_index);
+                    collect_rust_proto_ident_imports(request, package_name, package_by_ident, proto_type_index, client_imports, &mut imports);
+                    collect_rust_proto_ident_imports(response, package_name, package_by_ident, proto_type_index, client_imports, &mut imports);
+                    for arg in method.request_generic_args {
+                        collect_rust_proto_ident_imports(
+                            resolve_transparent_ident(**arg, ident_index),
+                            package_name,
+                            package_by_ident,
+                            proto_type_index,
+                            client_imports,
+                            &mut imports,
+                        );
+                    }
+                    for arg in method.response_generic_args {
+                        collect_rust_proto_ident_imports(
+                            resolve_transparent_ident(**arg, ident_index),
+                            package_name,
+                            package_by_ident,
+                            proto_type_index,
+                            client_imports,
+                            &mut imports,
+                        );
+                    }
+                }
+            }
+            ProtoEntry::SimpleEnum { .. } | ProtoEntry::Import { .. } => {}
+        }
+    }
+    imports
+}
+
+fn collect_rust_field_imports(
+    field: &Field,
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    imports: &mut BTreeSet<String>,
+) {
+    let ident = resolve_transparent_ident(field.rust_proto_ident, ident_index);
+    collect_rust_proto_ident_imports(ident, package_name, package_by_ident, proto_type_index, client_imports, imports);
+    for arg in field.generic_args {
+        let arg = resolve_transparent_ident(**arg, ident_index);
+        collect_rust_proto_ident_imports(arg, package_name, package_by_ident, proto_type_index, client_imports, imports);
+    }
+}
+
+fn collect_rust_proto_ident_imports(
+    ident: ProtoIdent,
+    package_name: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    imports: &mut BTreeSet<String>,
+) {
+    if ident.proto_type.starts_with("map<") {
+        if let Some((key, value)) = parse_map_types(ident.proto_type) {
+            collect_rust_proto_name_imports(key, package_name, package_by_ident, proto_type_index, client_imports, imports);
+            collect_rust_proto_name_imports(value, package_name, package_by_ident, proto_type_index, client_imports, imports);
+        }
+        return;
+    }
+
+    let type_name = rust_type_name(ident);
+    if let Some(import) = client_imports.get(&type_name) {
+        imports.insert(import.render_use());
+        return;
+    }
+
+    let package = package_by_ident
+        .get(&ident)
+        .map(String::as_str)
+        .or(if ident.proto_package_name.is_empty() { None } else { Some(ident.proto_package_name) });
+
+    if let Some(package) = package
+        && !package.is_empty()
+        && package != package_name
+    {
+        imports.insert(format!("crate::{}::{}", module_path_for_package(package), type_name));
+    }
+}
+
+fn collect_rust_proto_name_imports(
+    proto_name: &str,
+    package_name: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    imports: &mut BTreeSet<String>,
+) {
+    if proto_scalar_type(proto_name).is_some() {
+        return;
+    }
+    if proto_name.starts_with("map<") {
+        if let Some((key, value)) = parse_map_types(proto_name) {
+            collect_rust_proto_name_imports(key, package_name, package_by_ident, proto_type_index, client_imports, imports);
+            collect_rust_proto_name_imports(value, package_name, package_by_ident, proto_type_index, client_imports, imports);
+        }
+        return;
+    }
+    if let Some(candidates) = proto_type_index.get(proto_name) {
+        if let Some(candidate) = candidates.iter().find(|ident| package_by_ident.get(*ident).is_some_and(|pkg| pkg == package_name)) {
+            collect_rust_proto_ident_imports(*candidate, package_name, package_by_ident, proto_type_index, client_imports, imports);
+            return;
+        }
+        if let Some(candidate) = candidates.first() {
+            collect_rust_proto_ident_imports(*candidate, package_name, package_by_ident, proto_type_index, client_imports, imports);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_entries(
+    output: &mut String,
+    entries: &[&'static ProtoSchema],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut ordered_entries = entries.to_vec();
+    ordered_entries.sort_by(|left, right| super::utils::entry_sort_key(left).cmp(&super::utils::entry_sort_key(right)));
+
+    let mut seen = BTreeSet::new();
+    for entry in ordered_entries {
+        let type_name = rust_type_name(entry.id);
+        if !seen.insert(type_name) {
+            continue;
+        }
+        if let Some(definition) = render_rust_entry(entry, package_name, ident_index, package_by_ident, proto_type_index, client_imports, indent) {
+            output.push_str(&definition);
+            output.push('\n');
+        }
+    }
+}
+
+fn render_rust_entry(
+    entry: &ProtoSchema,
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) -> Option<String> {
+    match entry.content {
+        ProtoEntry::Struct { fields } => Some(render_rust_struct(entry, fields, package_name, ident_index, package_by_ident, proto_type_index, client_imports, indent)),
+        ProtoEntry::SimpleEnum { variants } => Some(render_rust_simple_enum(entry, variants, indent)),
+        ProtoEntry::ComplexEnum { variants } => Some(render_rust_complex_enum(
+            entry,
+            variants,
+            package_name,
+            ident_index,
+            package_by_ident,
+            proto_type_index,
+            client_imports,
+            indent,
+        )),
+        ProtoEntry::Import { .. } => None,
+        ProtoEntry::Service { methods, rpc_package_name } => Some(render_rust_service(
+            entry,
+            methods,
+            rpc_package_name,
+            package_name,
+            ident_index,
+            package_by_ident,
+            proto_type_index,
+            client_imports,
+            indent,
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_rust_struct(
+    entry: &ProtoSchema,
+    fields: &[&Field],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) -> String {
+    let mut output = String::new();
+    let type_name = rust_type_name(entry.id);
+    let generics = render_generics(entry);
+    let is_tuple = fields.iter().all(|field| field.name.is_none());
+
+    render_top_level_attributes(&mut output, entry, indent);
+
+    indent_line(&mut output, indent);
+    if fields.is_empty() {
+        output.write_fmt(format_args!("pub struct {type_name}{generics};\n")).unwrap();
+        return output;
+    }
+
+    if is_tuple {
+        output.write_fmt(format_args!("pub struct {type_name}{generics}(\n")).unwrap();
+
+        for (idx, field) in fields.iter().enumerate() {
+            render_field_attributes(&mut output, field, idx, indent + 4);
+            indent_line(&mut output, indent + 4);
+            output.push_str("pub ");
+            output.push_str(&render_field_type(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports));
+            output.push_str(",\n");
+        }
+        indent_line(&mut output, indent);
+        output.push_str(");\n");
+        return output;
+    }
+    output.write_fmt(format_args!("pub struct {type_name}{generics} {{\n")).unwrap();
+
+    for (idx, field) in fields.iter().enumerate() {
+        render_field_attributes(&mut output, field, idx, indent + 4);
+        indent_line(&mut output, indent + 4);
+        let name = field.name.unwrap_or("field");
+        output.push_str("pub ");
+        output.push_str(name);
+        output.push_str(": ");
+        output.push_str(&render_field_type(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports));
+        output.push_str(",\n");
+    }
+    indent_line(&mut output, indent);
+    output.push_str("}\n");
+    output
+}
+
+fn render_rust_simple_enum(entry: &ProtoSchema, variants: &[&Variant], indent: usize) -> String {
+    let mut output = String::new();
+    let type_name = rust_type_name(entry.id);
+    let generics = render_generics(entry);
+
+    render_top_level_attributes(&mut output, entry, indent);
+    indent_line(&mut output, indent);
+    output.write_fmt(format_args!("pub enum {type_name}{generics} {{\n")).unwrap();
+
+    for variant in variants {
+        indent_line(&mut output, indent + 4);
+        output.push_str(variant.name);
+        if let Some(discriminant) = variant.discriminant {
+            output.write_fmt(format_args!(" = {discriminant}")).unwrap();
+        }
+        output.push_str(",\n");
+    }
+    indent_line(&mut output, indent);
+    output.push_str("}\n");
+    output
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_rust_complex_enum(
+    entry: &ProtoSchema,
+    variants: &[&Variant],
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) -> String {
+    let mut output = String::new();
+    let type_name = rust_type_name(entry.id);
+    let generics = render_generics(entry);
+
+    render_top_level_attributes(&mut output, entry, indent);
+    indent_line(&mut output, indent);
+    output.write_fmt(format_args!("pub enum {type_name}{generics} {{\n")).unwrap();
+
+    for variant in variants {
+        indent_line(&mut output, indent + 4);
+        output.push_str(variant.name);
+        if variant.fields.is_empty() {
+            output.push_str(",\n");
+            continue;
+        }
+
+        let has_named = variant.fields.iter().any(|field| field.name.is_some());
+        if has_named {
+            output.push_str(" {\n");
+            for (idx, field) in variant.fields.iter().enumerate() {
+                render_field_attributes(&mut output, field, idx, indent + 8);
+                indent_line(&mut output, indent + 8);
+                let name = field.name.unwrap_or("field");
+                output.push_str(name);
+                output.push_str(": ");
+                output.push_str(&render_field_type(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports));
+                output.push_str(",\n");
+            }
+            indent_line(&mut output, indent + 4);
+            output.push_str("},\n");
+        } else {
+            output.push_str("(\n");
+            for (idx, field) in variant.fields.iter().enumerate() {
+                render_field_attributes(&mut output, field, idx, indent + 8);
+                indent_line(&mut output, indent + 8);
+                output.push_str(&render_field_type(field, package_name, ident_index, package_by_ident, proto_type_index, client_imports));
+                output.push_str(",\n");
+            }
+            indent_line(&mut output, indent + 4);
+            output.push_str("),\n");
+        }
+    }
+    indent_line(&mut output, indent);
+    output.push_str("}\n");
+    output
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_rust_service(
+    entry: &ProtoSchema,
+    methods: &[&ServiceMethod],
+    rpc_package_name: &str,
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+    indent: usize,
+) -> String {
+    let mut output = String::new();
+    let trait_name = rust_type_name(entry.id);
+    let generics = render_generics(entry);
+
+    indent_line(&mut output, indent);
+    output.push_str("#[proto_rpc(rpc_package = \"");
+    output.push_str(rpc_package_name);
+    output.push_str("\", rpc_server = false, rpc_client = true)]\n");
+    indent_line(&mut output, indent);
+    writeln!(output, "pub trait {trait_name}{generics} {{").unwrap();
+
+    let mut stream_types = Vec::new();
+    for method in methods {
+        if method.server_streaming {
+            let stream_name = format!("{}Stream", method.name);
+            let response_ident = resolve_transparent_ident(method.response, ident_index);
+            let item_type = render_proto_type_with_generics(response_ident, method.response_generic_args, package_name, package_by_ident, proto_type_index, client_imports);
+            stream_types.push(stream_name.clone());
+            indent_line(&mut output, indent + 4);
+            writeln!(
+                output,
+                "type {stream_name}: ::tonic::codegen::tokio_stream::Stream<Item = ::core::result::Result<{item_type}, ::tonic::Status>> + ::core::marker::Send;"
+            )
+            .unwrap();
+        }
+    }
+
+    if !stream_types.is_empty() {
+        output.push('\n');
+    }
+
+    for method in methods {
+        let request_ident = resolve_transparent_ident(method.request, ident_index);
+        let request_type = render_proto_type_with_generics(request_ident, method.request_generic_args, package_name, package_by_ident, proto_type_index, client_imports);
+        let response_type = if method.server_streaming {
+            format!("Self::{}Stream", method.name)
+        } else {
+            let response_ident = resolve_transparent_ident(method.response, ident_index);
+            render_proto_type_with_generics(response_ident, method.response_generic_args, package_name, package_by_ident, proto_type_index, client_imports)
+        };
+
+        indent_line(&mut output, indent + 4);
+        writeln!(output, "async fn {}(", to_snake_case(method.name)).unwrap();
+        indent_line(&mut output, indent + 8);
+        writeln!(output, "&self,").unwrap();
+        indent_line(&mut output, indent + 8);
+        writeln!(output, "request: ::tonic::Request<{request_type}>,").unwrap();
+        indent_line(&mut output, indent + 4);
+        output.push_str(") -> ::core::result::Result<::tonic::Response<");
+        output.push_str(&response_type);
+        output.push_str(">, ::tonic::Status>;\n\n");
+    }
+
+    indent_line(&mut output, indent);
+    output.push_str("}\n");
+    output
+}
+
+fn render_top_level_attributes(output: &mut String, entry: &ProtoSchema, indent: usize) {
+    let mut has_proto_message = false;
+    for attr in entry.top_level_attributes {
+        if attr.path == "proto_message" {
+            has_proto_message = true;
+            indent_line(output, indent);
+            output.push_str(attr.tokens);
+            output.push('\n');
+        }
+    }
+    if !has_proto_message {
+        indent_line(output, indent);
+        output.push_str("#[proto_message]\n");
+    }
+}
+
+fn render_field_attributes(output: &mut String, field: &Field, idx: usize, indent: usize) {
+    let expected_tag = idx as u32 + 1;
+    let mut emitted = false;
+    for attr in field.attributes {
+        if attr.path == "proto" {
+            if is_tag_only_attr(attr.tokens, expected_tag) {
+                continue;
+            }
+            emitted = true;
+            indent_line(output, indent);
+            output.push_str(attr.tokens);
+            output.push('\n');
+        }
+    }
+    if !emitted && field.tag > 0 && field.tag != expected_tag {
+        indent_line(output, indent);
+        output.write_fmt(format_args!("#[proto(tag = {})]\n", field.tag)).unwrap();
+    }
+}
+
+fn is_tag_only_attr(tokens: &str, expected_tag: u32) -> bool {
+    let normalized = tokens.replace(' ', "");
+    let inner = normalized.strip_prefix("#[proto(").and_then(|value| value.strip_suffix(")]"));
+    let Some(inner) = inner else {
+        return false;
+    };
+    let mut parts = inner.split(',');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    let Some(tag_value) = first.strip_prefix("tag=") else {
+        return false;
+    };
+    tag_value.parse::<u32>().ok().is_some_and(|tag| tag == expected_tag)
+}
+
+fn render_field_type(
+    field: &Field,
+    package_name: &str,
+    ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> String {
+    if let Some(array_len) = field.array_len {
+        let elem_ident = field.array_elem.unwrap_or(field.proto_ident);
+        let elem_type = if field.array_is_bytes {
+            "u8".to_string()
+        } else {
+            render_proto_type(elem_ident, package_name, package_by_ident, proto_type_index, client_imports)
+        };
+        return format!("[{elem_type}; {array_len}]");
+    }
+
+    let ident = resolve_transparent_ident(field.rust_proto_ident, ident_index);
+    let base = render_proto_type_with_generics(ident, field.generic_args, package_name, package_by_ident, proto_type_index, client_imports);
+    match field.proto_label {
+        ProtoLabel::None => base,
+        ProtoLabel::Optional => format!("::core::option::Option<{base}>"),
+        ProtoLabel::Repeated => format!("::proto_rs::alloc::vec::Vec<{base}>"),
+    }
+}
+
+fn render_proto_type(
+    ident: ProtoIdent,
+    current_package: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> String {
+    if ident.proto_type.starts_with("map<") {
+        return render_map_type(ident.proto_type, current_package, package_by_ident, proto_type_index, client_imports);
+    }
+    if ident.module_path.is_empty()
+        && ident.proto_file_path.is_empty()
+        && ident.proto_package_name.is_empty()
+        && let Some(scalar) = proto_scalar_type(ident.proto_type)
+    {
+        return scalar.to_string();
+    }
+
+    let type_name = rust_type_name(ident);
+    if let Some(import) = client_imports.get(&type_name) {
+        return import.render_type();
+    }
+    let package = package_by_ident
+        .get(&ident)
+        .map(String::as_str)
+        .or(if ident.proto_package_name.is_empty() { None } else { Some(ident.proto_package_name) });
+
+    match package {
+        Some(package) if package == current_package => type_name,
+        Some(package) if !package.is_empty() => type_name,
+        _ => type_name,
+    }
+}
+
+fn render_proto_type_with_generics(
+    ident: ProtoIdent,
+    generic_args: &[&ProtoIdent],
+    current_package: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> String {
+    let base = render_proto_type(ident, current_package, package_by_ident, proto_type_index, client_imports);
+    if generic_args.is_empty() {
+        return base;
+    }
+    let rendered_args: Vec<String> = generic_args
+        .iter()
+        .map(|arg| render_proto_type(**arg, current_package, package_by_ident, proto_type_index, client_imports))
+        .collect();
+    format!("{base}<{}>", rendered_args.join(", "))
+}
+
+fn render_map_type(
+    proto_type: &str,
+    current_package: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> String {
+    let Some((key, value)) = parse_map_types(proto_type) else {
+        return "::proto_rs::alloc::collections::BTreeMap<::core::primitive::u32, ::core::primitive::u32>".to_string();
+    };
+    let key_type = proto_name_to_rust_type(key, current_package, package_by_ident, proto_type_index, client_imports);
+    let value_type = proto_name_to_rust_type(value, current_package, package_by_ident, proto_type_index, client_imports);
+    format!("::proto_rs::alloc::collections::BTreeMap<{key_type}, {value_type}>")
+}
+
+fn proto_name_to_rust_type(
+    proto_name: &str,
+    current_package: &str,
+    package_by_ident: &BTreeMap<ProtoIdent, String>,
+    proto_type_index: &BTreeMap<String, Vec<ProtoIdent>>,
+    client_imports: &BTreeMap<String, ClientImport>,
+) -> String {
+    if let Some(scalar) = proto_scalar_type(proto_name) {
+        return scalar.to_string();
+    }
+    if proto_name.starts_with("map<") {
+        return render_map_type(proto_name, current_package, package_by_ident, proto_type_index, client_imports);
+    }
+
+    if let Some(candidates) = proto_type_index.get(proto_name) {
+        if let Some(candidate) = candidates.iter().find(|ident| package_by_ident.get(*ident).is_some_and(|pkg| pkg == current_package)) {
+            return render_proto_type(*candidate, current_package, package_by_ident, proto_type_index, client_imports);
+        }
+        if let Some(candidate) = candidates.first() {
+            return render_proto_type(*candidate, current_package, package_by_ident, proto_type_index, client_imports);
+        }
+    }
+
+    proto_name.to_string()
+}
+
+fn render_generics(entry: &ProtoSchema) -> String {
+    if entry.generics.is_empty() && entry.lifetimes.is_empty() {
+        return String::new();
+    }
+
+    let mut params = Vec::new();
+
+    for lifetime in entry.lifetimes {
+        let mut lifetime_param = format!("'{}", lifetime.name);
+        if !lifetime.bounds.is_empty() {
+            lifetime_param.push_str(": ");
+            lifetime_param.push_str(&lifetime.bounds.join(" + "));
+        }
+        params.push(lifetime_param);
+    }
+
+    for generic in entry.generics {
+        match generic.kind {
+            GenericKind::Type => {
+                let mut param = generic.name.to_string();
+                if !generic.constraints.is_empty() {
+                    param.push_str(": ");
+                    param.push_str(&generic.constraints.join(" + "));
+                }
+                params.push(param);
+            }
+            GenericKind::Const => {
+                let const_type = generic.const_type.unwrap_or("usize");
+                params.push(format!("const {}: {const_type}", generic.name));
+            }
+        }
+    }
+
+    format!("<{}>", params.join(", "))
+}
+
+fn build_proto_type_index(registry: &BTreeMap<String, Vec<&'static ProtoSchema>>) -> BTreeMap<String, Vec<ProtoIdent>> {
+    let mut index = BTreeMap::new();
+    for entries in registry.values() {
+        for entry in entries {
+            index.entry(entry.id.proto_type.to_string()).or_insert_with(Vec::new).push(entry.id);
+        }
+    }
+    index
+}
+
+fn package_name_for_entries(file_name: &str, entries: &[&ProtoSchema]) -> String {
+    let path = Path::new(file_name);
+    let file_name_last = path.file_name().and_then(|name| name.to_str()).unwrap_or(file_name);
+    entries
+        .first()
+        .map(|schema| schema.id.proto_package_name)
+        .filter(|name| !name.is_empty())
+        .map_or_else(|| super::utils::derive_package_name(file_name_last), ToString::to_string)
+}

--- a/src/schemas/utils.rs
+++ b/src/schemas/utils.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeMap;
+
+use super::ProtoEntry;
+use super::ProtoIdent;
+use super::ProtoSchema;
+
+pub(crate) fn derive_package_name(file_path: &str) -> String {
+    file_path.trim_end_matches(".proto").replace(['/', '\\', '-', '.'], "_").to_lowercase()
+}
+
+pub(crate) fn module_path_segments(package_name: &str) -> Vec<String> {
+    package_name.split('.').filter(|segment| !segment.is_empty()).map(sanitize_module_segment).collect()
+}
+
+pub(crate) fn module_path_for_package(package_name: &str) -> String {
+    module_path_segments(package_name).join("::")
+}
+
+pub(crate) fn sanitize_module_segment(segment: &str) -> String {
+    let mut out = String::new();
+    for ch in segment.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+    if out.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    if out.is_empty() { "_".to_string() } else { out }
+}
+
+pub(crate) fn indent_line(output: &mut String, indent: usize) {
+    for _ in 0..indent {
+        output.push(' ');
+    }
+}
+
+pub(crate) fn strip_proto_suffix(type_name: &str) -> String {
+    type_name.strip_suffix("Proto").unwrap_or(type_name).to_string()
+}
+
+pub(crate) fn rust_type_name(ident: ProtoIdent) -> String {
+    strip_proto_suffix(ident.name)
+}
+
+pub(crate) fn proto_scalar_type(proto_type: &str) -> Option<&'static str> {
+    match proto_type {
+        "double" => Some("f64"),
+        "float" => Some("f32"),
+        "int32" | "sint32" | "sfixed32" => Some("i32"),
+        "int64" | "sint64" | "sfixed64" => Some("i64"),
+        "uint32" | "fixed32" => Some("u32"),
+        "uint64" | "fixed64" => Some("u64"),
+        "bool" => Some("bool"),
+        "string" => Some("::proto_rs::alloc::string::String"),
+        "bytes" => Some("::proto_rs::alloc::vec::Vec<u8>"),
+        _ => None,
+    }
+}
+
+pub(crate) fn parse_map_types(proto_type: &str) -> Option<(&str, &str)> {
+    let inner = proto_type.strip_prefix("map<")?.strip_suffix('>')?;
+    let mut parts = inner.splitn(2, ',');
+    let key = parts.next()?.trim();
+    let value = parts.next()?.trim();
+    Some((key, value))
+}
+
+pub(crate) fn entry_sort_key(entry: &ProtoSchema) -> (u8, &'static str) {
+    let kind = match entry.content {
+        ProtoEntry::Import { .. } => 0,
+        ProtoEntry::SimpleEnum { .. } => 1,
+        ProtoEntry::Struct { .. } => 2,
+        ProtoEntry::ComplexEnum { .. } => 3,
+        ProtoEntry::Service { .. } => 4,
+    };
+    (kind, entry.id.proto_type)
+}
+
+pub(crate) fn resolve_transparent_ident(ident: ProtoIdent, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>) -> ProtoIdent {
+    transparent_inner_ident(&ident, ident_index).unwrap_or(ident)
+}
+
+fn transparent_inner_ident(ident: &ProtoIdent, ident_index: &BTreeMap<ProtoIdent, &'static ProtoSchema>) -> Option<ProtoIdent> {
+    let schema = ident_index.get(ident)?;
+    if !is_transparent_schema(schema) {
+        return None;
+    }
+
+    match schema.content {
+        ProtoEntry::Struct { fields } if fields.len() == 1 => Some(fields[0].proto_ident),
+        _ => None,
+    }
+}
+
+fn is_transparent_schema(schema: &ProtoSchema) -> bool {
+    schema.top_level_attributes.iter().any(|attr| attr.path == "proto_message" && attr.tokens.contains("transparent"))
+}
+
+pub(crate) fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut chars = s.chars().peekable();
+    let mut prev_is_lower = false;
+    let mut prev_is_upper = false;
+
+    while let Some(c) = chars.next() {
+        let next_is_upper = chars.peek().is_some_and(|ch| ch.is_uppercase());
+        let next_is_lower = chars.peek().is_some_and(|ch| ch.is_lowercase());
+
+        if c.is_uppercase() && !result.is_empty() && (prev_is_lower || prev_is_upper && (next_is_upper || next_is_lower)) {
+            result.push('_');
+        }
+
+        result.push(c.to_ascii_lowercase());
+        prev_is_lower = c.is_lowercase();
+        prev_is_upper = c.is_uppercase();
+    }
+
+    result
+}

--- a/tests/proto_build_test/src/client.rs
+++ b/tests/proto_build_test/src/client.rs
@@ -17,43 +17,20 @@ pub mod extra_types {
 
     #[proto_message]
     pub struct BuildRequest {
-        #[proto(tag = 1)]
         pub config: BuildConfig,
-        #[proto(tag = 2)]
         pub ping: RizzPing,
-        #[proto(tag = 3)]
         pub owner: Id,
     }
 
     #[proto_message]
     pub struct BuildResponse {
-        #[proto(tag = 1)]
         pub status: ServiceStatus,
-        #[proto(tag = 2)]
-        pub envelope: Envelope,
+        pub envelope: Envelope<GoonPong>,
     }
 
     #[proto_message]
     pub struct Envelope<T> {
-        #[proto(tag = 1)]
-        pub payload: BuildRequest,
-        #[proto(tag = 2)]
-        pub trace_id: ::proto_rs::alloc::string::String,
-    }
-
-    #[proto_message]
-    pub struct Envelope<T> {
-        #[proto(tag = 1)]
-        pub payload: BuildResponse,
-        #[proto(tag = 2)]
-        pub trace_id: ::proto_rs::alloc::string::String,
-    }
-
-    #[proto_message]
-    pub struct Envelope<T> {
-        #[proto(tag = 1)]
-        pub payload: GoonPong,
-        #[proto(tag = 2)]
+        pub payload: T,
         pub trace_id: ::proto_rs::alloc::string::String,
     }
 
@@ -63,37 +40,11 @@ pub mod fastnum {
     use proto_rs::{proto_message, proto_rpc};
 
     #[proto_message]
-    pub struct D128Proto {
-        #[proto(tag = 1)]
+    pub struct D128 {
         pub lo: u64,
-        #[proto(tag = 2)]
         pub hi: u64,
-        #[proto(tag = 3)]
         pub fractional_digits_count: i32,
-        #[proto(tag = 4)]
         pub is_negative: bool,
-    }
-
-    #[proto_message]
-    pub struct D128Proto {
-        #[proto(tag = 1)]
-        pub lo: u64,
-        #[proto(tag = 2)]
-        pub hi: u64,
-        #[proto(tag = 3)]
-        pub fractional_digits_count: i32,
-        #[proto(tag = 4)]
-        pub is_negative: bool,
-    }
-
-    #[proto_message]
-    pub struct UD128Proto {
-        #[proto(tag = 1)]
-        pub lo: u64,
-        #[proto(tag = 2)]
-        pub hi: u64,
-        #[proto(tag = 3)]
-        pub fractional_digits_count: i32,
     }
 
 }
@@ -111,23 +62,18 @@ pub mod goon_types {
 
     #[proto_message]
     pub struct GoonPong {
-        #[proto(tag = 1)]
         pub id: Id,
-        #[proto(tag = 2)]
         pub status: ServiceStatus,
     }
 
     #[proto_message]
     pub struct Id {
-        #[proto(tag = 1)]
         pub id: u64,
     }
 
     #[proto_message]
     pub struct RizzPing {
-        #[proto(tag = 1)]
         pub id: Id,
-        #[proto(tag = 2)]
         pub status: ServiceStatus,
     }
 
@@ -146,54 +92,45 @@ pub mod rizz_types {
 pub mod sigma_rpc_simple {
     #[allow(unused_imports)]
     use proto_rs::{proto_message, proto_rpc};
+    use crate::extra_types::BuildRequest;
     use crate::extra_types::BuildResponse;
     use crate::extra_types::Envelope;
-    use crate::fastnum::D128Proto;
-    use crate::fastnum::UD128Proto;
+    use crate::fastnum::D128;
     use crate::goon_types::GoonPong;
     use crate::goon_types::Id;
     use crate::goon_types::RizzPing;
     use crate::rizz_types::BarSub;
     use crate::rizz_types::FooResponse;
+    use fastnum::UD128;
 
     #[proto_rpc(rpc_package = "sigma_rpc", rpc_server = false, rpc_client = true)]
     pub trait SigmaRpc {
-        type RizzUniStream: ::tonic::codegen::tokio_stream::Stream<Item = ::core::result::Result<FooResponse, ::tonic::Status>> + ::core::marker::Send + 'static;
+        type RizzUniStream: ::tonic::codegen::tokio_stream::Stream<Item = ::core::result::Result<FooResponse, ::tonic::Status>> + ::core::marker::Send;
 
         async fn rizz_ping(
             &self,
             request: ::tonic::Request<RizzPing>,
-        ) -> ::core::result::Result<::tonic::Response<GoonPong>, ::tonic::Status>
-        where
-            Self: ::core::marker::Send + ::core::marker::Sync;
+        ) -> ::core::result::Result<::tonic::Response<GoonPong>, ::tonic::Status>;
 
         async fn rizz_uni(
             &self,
             request: ::tonic::Request<BarSub>,
-        ) -> ::core::result::Result<::tonic::Response<Self::RizzUniStream>, ::tonic::Status>
-        where
-            Self: ::core::marker::Send + ::core::marker::Sync;
+        ) -> ::core::result::Result<::tonic::Response<Self::RizzUniStream>, ::tonic::Status>;
 
         async fn build(
             &self,
-            request: ::tonic::Request<Envelope>,
-        ) -> ::core::result::Result<::tonic::Response<Envelope>, ::tonic::Status>
-        where
-            Self: ::core::marker::Send + ::core::marker::Sync;
+            request: ::tonic::Request<Envelope<BuildRequest>>,
+        ) -> ::core::result::Result<::tonic::Response<Envelope<BuildResponse>>, ::tonic::Status>;
 
         async fn owner_lookup(
             &self,
             request: ::tonic::Request<Id>,
-        ) -> ::core::result::Result<::tonic::Response<BuildResponse>, ::tonic::Status>
-        where
-            Self: ::core::marker::Send + ::core::marker::Sync;
+        ) -> ::core::result::Result<::tonic::Response<BuildResponse>, ::tonic::Status>;
 
         async fn test_decimals(
             &self,
-            request: ::tonic::Request<UD128Proto>,
-        ) -> ::core::result::Result<::tonic::Response<D128Proto>, ::tonic::Status>
-        where
-            Self: ::core::marker::Send + ::core::marker::Sync;
+            request: ::tonic::Request<UD128>,
+        ) -> ::core::result::Result<::tonic::Response<D128>, ::tonic::Status>;
 
     }
 
@@ -203,25 +140,22 @@ pub mod solana {
     use proto_rs::{proto_message, proto_rpc};
 
     #[proto_message]
-    pub struct AddressProto {
-        #[proto(tag = 1)]
-        pub inner: ::proto_rs::alloc::vec::Vec<u8>,
+    pub struct Address {
+        pub inner: [u8; BYTES],
     }
 
     #[proto_message]
-    pub struct KeypairProto {
-        #[proto(tag = 1)]
-        pub inner: ::proto_rs::alloc::vec::Vec<u8>,
+    pub struct Keypair {
+        pub inner: [u8; BYTES],
     }
 
     #[proto_message]
-    pub struct SignatureProto {
-        #[proto(tag = 1)]
-        pub inner: ::proto_rs::alloc::vec::Vec<u8>,
+    pub struct Signature {
+        pub inner: [u8; BYTES],
     }
 
     #[proto_message]
-    pub enum InstructionErrorProto {
+    pub enum InstructionError {
         GenericError,
         InvalidArgument,
         InvalidInstructionData,
@@ -248,7 +182,6 @@ pub mod solana {
         AccountBorrowOutstanding,
         DuplicateAccountOutOfSync,
         Custom(
-            #[proto(tag = 1)]
             u32,
         ),
         InvalidError,
@@ -282,7 +215,7 @@ pub mod solana {
     }
 
     #[proto_message]
-    pub enum TransactionErrorProto {
+    pub enum TransactionError {
         AccountInUse,
         AccountLoadedTwice,
         AccountNotFound,
@@ -292,10 +225,8 @@ pub mod solana {
         AlreadyProcessed,
         BlockhashNotFound,
         InstructionError {
-            #[proto(tag = 1)]
             index: u32,
-            #[proto(tag = 2)]
-            error: InstructionErrorProto,
+            error: InstructionError,
         },
         CallChainTooDeep,
         MissingSignatureForFee,
@@ -319,18 +250,15 @@ pub mod solana {
         WouldExceedMaxVoteCostLimit,
         WouldExceedAccountDataTotalLimit,
         DuplicateInstruction(
-            #[proto(tag = 1)]
             u32,
         ),
         InsufficientFundsForRent {
-            #[proto(tag = 1)]
             account_index: u32,
         },
         MaxLoadedAccountsDataSizeExceeded,
         InvalidLoadedAccountsDataSizeLimit,
         ResanitizationNeeded,
         ProgramExecutionTemporarilyRestricted {
-            #[proto(tag = 1)]
             account_index: u32,
         },
         UnbalancedTransaction,


### PR DESCRIPTION
### Motivation
- Fix incorrect Rust client code generation that produced duplicate concrete generic structs instead of using generic parameters and emitted wrong type names.
- Preserve array types and byte-array semantics from original Rust types into generated client code instead of converting arrays to `Vec`.
- Avoid emitting unnecessary `#[proto(tag = ...)]` annotations and unnecessary `Send + Sync` / `+ 'static` bounds on generated RPC-associated types and methods.
- Improve maintainability by splitting the large `schema.rs` into focused modules and enriching schema metadata to support correct client rendering.

### Description
- Refactor `src/schemas.rs` into three modules: `src/schemas/proto_output.rs`, `src/schemas/rust_client.rs`, and `src/schemas/utils.rs` and wire them into `src/schemas.rs`.
- Extend the compile-time `ProtoSchema` data (fields and service methods) to include `rust_proto_ident`, `generic_args`, and array metadata (`array_len`, `array_is_bytes`, `array_elem`) so the Rust client generator can render correct types and imports.
- Change generation strategy for generics: do not honor `#[proto(generic_types)]` by emitting multiple generated Rust types; instead, detect concrete specializations by usage and generate concrete proto messages for those specializations (build-time specializations derived from usage).
- Improve Rust client output:
  - Strip `Proto` suffix from type names when rendering client code so generated type names match Rust idioms.
  - Render arrays as fixed-size arrays (`[T; N]`) and preserve byte-array detection as fixed `[u8; N]` instead of `Vec<u8>`.
  - Omit `#[proto(tag = ...)]` attributes when the field tag matches the natural order and skip emitting tag-only proto attributes.
  - Do not emit `where Self: Send + Sync` clauses on generated RPC methods and avoid `+ 'static` on associated stream types when unnecessary.
  - Render RPC method signatures and stream associated types without superfluous bounds and with correctly resolved generic types (e.g. `Envelope<T>` remains generic where appropriate).
- Consolidate duplicated logic and helper functions in `src/schemas/utils.rs` and move proto-specific and Rust-client-specific rendering into their respective modules.

### Testing
- Ran `cargo test -p proto_build_test`; the build and tests completed successfully (unit test driver reported "running 0 tests" and finished with status OK).
- Ran the test binary with `cargo run` from `tests/proto_build_test` to exercise the build-time schema collection and Rust client output generation, which executed and printed collected schemas (warnings about an unrelated `cfg` condition are present but do not affect correctness).
- Verified generated proto files under `tests/proto_build_test/build_protos` and the Rust client output at `tests/proto_build_test/src/client.rs` reflect the fixes: generics rendered correctly, arrays preserved, `Proto` suffix stripped, unnecessary tags and bounds removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602750e58c8321b836022e5e9dc67f)