### PR TITLE
Refactor ProtoIdent metadata for ProtoType support

### DIFF
--- a/crates/prosto_derive/src/impl_proto_ident.rs
+++ b/crates/prosto_derive/src/impl_proto_ident.rs
@@ -58,8 +58,10 @@ pub fn impl_proto_ident(input: TokenStream) -> TokenStream {
                     name: stringify!(#ty),
                     proto_package_name: "",
                     proto_file_path: "",
-                    proto_type: stringify!(#ty),
+                    proto_type: ::proto_rs::schemas::ProtoType::Message(stringify!(#ty)),
+                    generics: &[],
                 };
+                const PROTO_TYPE: ::proto_rs::schemas::ProtoType = ::proto_rs::schemas::ProtoType::Message(stringify!(#ty));
             }
         }
     } else {
@@ -71,8 +73,10 @@ pub fn impl_proto_ident(input: TokenStream) -> TokenStream {
                     name: stringify!(#ty),
                     proto_package_name: "",
                     proto_file_path: "",
-                    proto_type: stringify!(#ty),
+                    proto_type: ::proto_rs::schemas::ProtoType::Message(stringify!(#ty)),
+                    generics: &[],
                 };
+                const PROTO_TYPE: ::proto_rs::schemas::ProtoType = ::proto_rs::schemas::ProtoType::Message(stringify!(#ty));
             }
         }
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,12 +10,12 @@ pub mod custom_types {
 
     #[proto_message]
     pub struct BTreeMapMEx {
-        pub value: BTreeMap,
+        pub value: ::proto_rs::alloc::collections::BTreeMap<u32, MEx>,
     }
 
     #[proto_message]
     pub struct BTreeSetMEx {
-        pub value: MEx,
+        pub value: ::proto_rs::alloc::vec::Vec<MEx>,
     }
 
     #[proto_message]
@@ -50,12 +50,12 @@ pub mod custom_types {
 
     #[proto_message]
     pub struct HashMapMEx {
-        pub value: HashMap,
+        pub value: ::proto_rs::alloc::collections::BTreeMap<u32, MEx>,
     }
 
     #[proto_message]
     pub struct HashSetMEx {
-        pub value: MEx,
+        pub value: ::proto_rs::alloc::vec::Vec<MEx>,
     }
 
     #[proto_message]
@@ -70,17 +70,17 @@ pub mod custom_types {
 
     #[proto_message]
     pub struct OptionMEx {
-        pub value: MEx,
+        pub value: ::core::option::Option<MEx>,
     }
 
     #[proto_message]
     pub struct VecDequeMEx {
-        pub value: MEx,
+        pub value: ::proto_rs::alloc::vec::Vec<MEx>,
     }
 
     #[proto_message]
     pub struct VecMEx {
-        pub value: MEx,
+        pub value: ::proto_rs::alloc::vec::Vec<MEx>,
     }
 
 }

--- a/tests/proto_build_test/src/main.rs
+++ b/tests/proto_build_test/src/main.rs
@@ -238,7 +238,7 @@ use proto_rs::schemas::ProtoSchema;
 fn main() {
     let rust_client_path = "src/client.rs";
     let sigma_entries: HashSet<ProtoSchema> = inventory::iter::<ProtoSchema>()
-        .filter(|schema| schema.id.name == "SigmaRpc" && schema.id.proto_type != "Import")
+        .filter(|schema| schema.id.name == "SigmaRpc" && schema.id.proto_type != proto_rs::schemas::ProtoType::None)
         .cloned()
         .collect();
     println!("{:?}", sigma_entries);


### PR DESCRIPTION
### Motivation
- Replace the previous string-based `proto_type` and `WRAPPER` pattern with a typed `ProtoType` enum and explicit `generics` to represent proto semantics and wrappers.
- Simplify and centralize handling of wrapper/generic types so generated schema data is more structured and easier to reason about.
- Update derive macros and codegen to emit the new typed metadata so schema generation and Rust client rendering remain correct.
- Ensure map/primitive rendering and import resolution use the new typed representation.

### Description
- Introduced `ProtoType` enum and added `generics: &'static [ProtoIdent]` to `ProtoIdent` in `src/schemas.rs` and updated `ProtoIdentifiable` to expose `PROTO_TYPE` constant.
- Replaced string literal proto type usages with `ProtoType` values across schema implementations, wrapper types, and primitive impls (including `Option`, `Vec`, maps, sets, etc.).
- Updated derive code (`crates/prosto_derive/src/impl_proto_ident.rs` and `crates/prosto_derive/src/schema.rs`) to emit `ProtoType` values and `generics` from macros and helper functions, including map parsing for generated tokens.
- Reworked schema rendering helpers and rust-client code to use typed proto types: new helpers `proto_map_types`, `proto_type_name`, `proto_ident_base_type_name`, `proto_type_to_rust_type`, and wrapper utilities were added or adapted in `src/schemas/*`.
- Adjusted generated test helper and build-test filtering to compare against `ProtoType::None` for import schemas.
- Regenerated client code output under `src/client.rs` to reflect the typed proto rendering.

### Testing
- Ran `cargo run -p proto_build_test` to regenerate/check build-system test; it completed with a single cfg warning about an unrelated `stable` cfg and printed the collected schemas (successful).
- Ran `cargo test --all-features --no-run`; the workspace compiled the tests (finished compilation for test profile) with only benign warnings from examples.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d450b05c832197107e2e72e0790c)