### PR TITLE
Validate Proto types at compile time and fix RPC map/set codegen

### DIFF
--- a/crates/prosto_derive/src/impl_proto_ident.rs
+++ b/crates/prosto_derive/src/impl_proto_ident.rs
@@ -63,6 +63,8 @@ pub fn impl_proto_ident(input: TokenStream) -> TokenStream {
                 };
                 const PROTO_TYPE: ::proto_rs::schemas::ProtoType = ::proto_rs::schemas::ProtoType::Message(stringify!(#ty));
             }
+            #[cfg(feature = "build-schemas")]
+            const _: () = <#ty as ::proto_rs::schemas::ProtoIdentifiable>::_VALIDATOR;
         }
     } else {
         quote! {

--- a/crates/prosto_derive/src/schema.rs
+++ b/crates/prosto_derive/src/schema.rs
@@ -1424,7 +1424,7 @@ fn generic_param_name(ty: &Type, generics: &syn::Generics) -> Option<String> {
 }
 
 /// Check if a type references any generic parameters from the parent type
-fn type_references_generic_params(ty: &Type, generics: &syn::Generics) -> bool {
+pub(crate) fn type_references_generic_params(ty: &Type, generics: &syn::Generics) -> bool {
     match ty {
         Type::Path(path) => {
             // Check if this is a bare generic parameter

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -303,6 +303,8 @@ macro_rules! impl_proto_ident_primitive {
             };
             const PROTO_TYPE: ProtoType = $proto_type;
         }
+        #[cfg(feature = "build-schemas")]
+        const _: () = <$ty as ProtoIdentifiable>::_VALIDATOR;
     };
 }
 

--- a/tests/proto_build_test/build_protos/protos/build_system_test/custom_types.proto
+++ b/tests/proto_build_test/build_protos/protos/build_system_test/custom_types.proto
@@ -2,6 +2,14 @@
 syntax = "proto3";
 package custom_types;
 
+message BTreeMapU32MEx {
+  map<uint32, MEx> value = 1;
+}
+
+message BTreeSetMEx {
+  repeated MEx value = 1;
+}
+
 message CustomEx {
   MEx mutex = 1;
   uint64 mutex_copy = 2;
@@ -24,6 +32,14 @@ message CustomEx {
   repeated uint64 custom_vec_deque_copy = 19;
   repeated MEx custom_vec = 20;
   repeated MEx custom_vec_deque = 21;
+}
+
+message HashMapU32MEx {
+  map<uint32, MEx> value = 1;
+}
+
+message HashSetMEx {
+  repeated MEx value = 1;
 }
 
 message MEx {

--- a/tests/proto_build_test/build_protos/protos/build_system_test/sigma_rpc_simple.proto
+++ b/tests/proto_build_test/build_protos/protos/build_system_test/sigma_rpc_simple.proto
@@ -22,10 +22,10 @@ service SigmaRpc {
   rpc OptionEcho(MEx) returns (MEx);
   rpc VecEcho(MEx) returns (MEx);
   rpc VecDequeEcho(MEx) returns (MEx);
-  rpc HashMapEcho(map<uint32, MEx>) returns (map<uint32, MEx>);
-  rpc BtreeMapEcho(map<uint32, MEx>) returns (map<uint32, MEx>);
-  rpc HashSetEcho(MEx) returns (MEx);
-  rpc BtreeSetEcho(MEx) returns (MEx);
+  rpc HashMapEcho(custom_types.HashMapU32MEx) returns (custom_types.HashMapU32MEx);
+  rpc BtreeMapEcho(custom_types.BTreeMapU32MEx) returns (custom_types.BTreeMapU32MEx);
+  rpc HashSetEcho(custom_types.HashSetMEx) returns (custom_types.HashSetMEx);
+  rpc BtreeSetEcho(custom_types.BTreeSetMEx) returns (custom_types.BTreeSetMEx);
   rpc MexEcho(custom_types.MEx) returns (custom_types.MEx);
   rpc TestDecimals(fastnum.UD128) returns (fastnum.D64);
 }


### PR DESCRIPTION
### Motivation
- Ensure proto type definitions are validated at compile time by running the existing `ProtoType` validator for all concrete types and macro-generated impls.
- Produce correct .proto output for RPC methods that use Rust collection wrappers (maps/sets) so they appear as message wrappers in .proto files and use concatenated names per protobuf rules.
- Keep build system outputs (tests/proto_build_test generated protos) consistent with protobuf expectations for map/set wrappers.

### Description
- Emit validator consts that reference `ProtoIdentifiable::_VALIDATOR` for manual impls and macro-generated types so validation is executed during compilation (`src/schemas.rs`, `crates/prosto_derive/src/impl_proto_ident.rs`).
- Wire validator emission into `proto_message` and `proto_rpc` codegen so concrete message types and RPC request/response types register validator consts (`crates/prosto_derive/src/proto_message/mod.rs`, `crates/prosto_derive/src/proto_rpc.rs`).
- Expose `type_references_generic_params` for use in the rpc macro to avoid validating types that depend on generic params (`crates/prosto_derive/src/schema.rs`).
- Refactor proto output generation to materialize wrapper messages for map/set wrappers and to render RPC method types using the concatenated wrapper message names (e.g., `HashMapU32MEx`, `HashSetMEx`) rather than inline `map<...>` or incorrect types (`src/schemas/proto_output.rs`).
- Regenerated build-system test proto files to reflect the new codegen for map/set wrappers (`tests/proto_build_test/build_protos/protos/build_system_test/custom_types.proto`, `tests/proto_build_test/build_protos/protos/build_system_test/sigma_rpc_simple.proto`).

### Testing
- Ran `cargo run -p proto_build_test` and inspected generated proto files; the run completed and produced expected wrapper message types for map/set RPCs (success).
- Ran the project test compile step `cargo test --all-features --no-run` to validate compilation across features; the build completed successfully (success).
- Ran `cargo run` in `tests/proto_build_test` to regenerate files and verify build-system end-to-end behavior; completed and updated generated protos (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696522e12b888321bee0cbe43724be2b)